### PR TITLE
chore: enforce lockfile sync in pre-commit + document version bump process

### DIFF
--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -1,5 +1,21 @@
 # Project Notes
 
+## Version Bumping
+
+Always use `npm version` to bump — it updates both `package.json` **and** `package-lock.json` atomically:
+
+```bash
+npm version patch   # 6.7.7 → 6.7.8
+npm version minor   # 6.7.7 → 6.8.0
+npm version major   # 6.7.7 → 7.0.0
+```
+
+Never manually edit `package.json` version — the pre-commit hook will reject the commit if `package-lock.json` is out of sync.
+
+The publish to npm happens automatically when the PR merges to `main` (CI detects the version diff vs npm registry).
+
+---
+
 ## Table Loading Behavior & Init Timing
 
 ### What Happens When `init()` is Called on a Loading Table?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rickcedwhat/playwright-smart-table",
-  "version": "6.7.7",
+  "version": "6.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rickcedwhat/playwright-smart-table",
-      "version": "6.7.7",
+      "version": "6.7.8",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/scripts/check-version-bump.mjs
+++ b/scripts/check-version-bump.mjs
@@ -52,6 +52,21 @@ try {
         }
 
         console.log('✅ CHANGELOG.md update confirmed.');
+
+        // 7. Verify package-lock.json is in sync
+        try {
+            const lockRaw = fs.readFileSync('package-lock.json', 'utf8');
+            const lockVersion = JSON.parse(lockRaw).version;
+            if (lockVersion !== currentVersion) {
+                console.error(`\n❌ ERROR: package-lock.json version (${lockVersion}) does not match package.json (${currentVersion}).`);
+                console.error('👉 Run: npm version patch (or minor/major) instead of editing package.json directly.');
+                console.error('   Or run: npm install --package-lock-only  to sync the lockfile.\n');
+                process.exit(1);
+            }
+            console.log('✅ package-lock.json is in sync.');
+        } catch (e) {
+            console.warn('⚠️ Could not verify package-lock.json:', e.message);
+        }
     }
 
 } catch (error) {


### PR DESCRIPTION
Follow-up to #23. These two commits landed on `release/6.7.8` after the merge so they didn't make it to `main`.

- Sync `package-lock.json` to 6.7.8
- Add step 7 to `check-version-bump.mjs`: rejects commits where `package-lock.json` version doesn't match `package.json`
- Document correct `npm version patch` workflow in `PROJECT_NOTES.md`