### PR TITLE
build: add devcontainer configuration for cloud IDEs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,5 +17,6 @@
       ]
     }
   },
-  "postCreateCommand": "npm install"
+  "postCreateCommand": "npm ci || npm install",
+  "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Playwright Smart Table",
+  "image": "mcr.microsoft.com/playwright:v1.49.1-noble",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20",
+      "nodeGypDependencies": true
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "github.copilot",
+        "github.copilot-chat"
+      ]
+    }
+  },
+  "postCreateCommand": "npm install"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
Separating the `.devcontainer` configuration from the previously merged PR 26!

This PR adds a `devcontainer.json` file that configures GitHub Codespaces and Copilot Workspaces to automatically boot with:
- Node 20
- Pre-installed Playwright OS dependencies

This prevents the default fallback to the an ancient Node 16 universal image, ensuring all tests and agents can run properly in Cloud IDEs.