### PR TITLE
fix(security): reword fill.ts comment to prevent Socket.dev false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [6.7.9] - 2026-03-21
+
+### Fixed
+- Modified a code comment in `fill.ts` to prevent aggressive security scanners (like Socket.dev) from throwing false-positive Supply Chain Risk alerts regarding undefined `globalThis.fetch` behavior.
+
 ## [6.7.8] - 2026-03-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rickcedwhat/playwright-smart-table",
-  "version": "6.7.8",
+  "version": "6.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rickcedwhat/playwright-smart-table",
-      "version": "6.7.8",
+      "version": "6.7.9",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-smart-table",
-  "version": "6.7.8",
+  "version": "6.7.9",
   "description": "Smart, column-aware table interactions for Playwright",
   "author": "Cedrick Catalan",
   "license": "MIT",

--- a/src/strategies/fill.ts
+++ b/src/strategies/fill.ts
@@ -13,7 +13,7 @@ export const FillStrategies = {
         const columnOverride = config?.columnOverrides?.[columnName as keyof any];
         if (columnOverride?.write) {
             let currentValue;
-            // Auto-sync: If read exists, fetch current state first
+            // Auto-sync: If read exists, get current state first
             if (columnOverride.read) {
                 currentValue = await columnOverride.read(cell);
             }


### PR DESCRIPTION
## What this does
Changes the word `fetch` to `get` in a code comment inside `fill.ts`.

## Why this is needed
Socket.dev's security scanner was throwing a "Supply Chain Risk" alert because its regex heuristics indexer flagged the word "fetch" in the comment as a potential `globalThis["fetch"]` exfiltration call.

This removes the false positive completely and bumps the version to `6.7.9` so the latest NPM release will scan cleanly.