### PR TITLE
chore: release 6.8.0 — changelog, README, API doc pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [6.8.0] - 2026-03-22
+
+### Added
+- **`concurrency` for row iteration** — `TableConfig` and `forEach` / `map` / `filter` options accept `concurrency: 'parallel' | 'sequential' | 'synchronized'`. `synchronized` runs navigation in parallel lock-step while serializing row callbacks (via `NavigationBarrier`), for grids where concurrent navigation would desync the viewport.
+- **`Mutex`** and **`NavigationBarrier`** utilities (`src/utils/mutex.ts`, `src/utils/navigationBarrier.ts`) with unit tests.
+- **Glide preset**: `aria-colindex`-based cell resolution, horizontal navigation on `.dvn-scroller`, `seekColumnIndex` / `snapFirstColumnIntoView`, default `concurrency: 'sequential'`, and canvas-aware fill with tighter textarea wait timeouts.
+
+### Changed
+- **`runMap`** (`src/engine/tableIteration.ts`) implements the three concurrency modes above; `parallel` option on iteration is deprecated in favor of `concurrency`.
+- **SmartRow** navigation: improved virtualized grid handling (`targetReached`, conditional `Home`, removal of row `scrollIntoViewIfNeeded` where it hung); navigation primitives extended on `NavigationPrimitives` (`snapFirstColumnIntoView`, `seekColumnIndex`).
+- **`.gitignore`**: local mapper / scratch `.txt` artifacts.
+
+### Documentation
+- README and API docs now describe `concurrency` for iteration; JSDoc on `TableResult` iteration methods updated accordingly.
+- `scripts/generate-all-api-docs.mjs`: match `TableResult` / `TableConfig` declarations correctly, fix single-line JSDoc leaving the parser stuck in “comment” mode, and recognize multi-line `forEach` / `map` / `filter` signatures so `tableresult-signatures.json` stays in sync with `types.ts`.
+
 ## [6.7.9] - 2026-03-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,16 +79,16 @@ const allActive = await table.findRows({ Status: 'Active' });
 ### Iterating Across Pages
 
 ```typescript
-// forEach — sequential, safe for interactions (parallel: false default)
+// forEach — sequential by default (concurrency: 'sequential') — safe for interactions
 await table.forEach(async ({ row, rowIndex, stop }) => {
   if (await row.getCell('Status').innerText() === 'Done') stop();
   await row.getCell('Checkbox').click();
 });
 
-// map — parallel within page, safe for reads (parallel: true default)
+// map — parallel by default (concurrency: 'parallel') — safe for reads
 const emails = await table.map(({ row }) => row.getCell('Email').innerText());
 
-// filter — async predicate across all pages, returns SmartRowArray
+// filter — sequential by default; returns SmartRowArray
 const active = await table.filter(async ({ row }) =>
   await row.getCell('Status').innerText() === 'Active'
 );
@@ -99,10 +99,14 @@ for await (const { row, rowIndex } of table) {
 }
 ```
 
+Set a default for all iteration calls with `useTable(..., { concurrency: 'sequential' })`, or per call: `table.map(fn, { concurrency: 'synchronized' })`. Modes: **`parallel`** (full parallelism), **`sequential`** (strictly one row at a time), **`synchronized`** (parallel navigation with serialized callbacks — useful for virtualized grids).
+
 When your pagination strategy supports bulk jumps (`goNextBulk`), pass `{ useBulkPagination: true }` to `map`/`forEach`/`filter` to advance by multiple pages at once.
 
-> **`map` + UI interactions:** `map` defaults to `parallel: true`. If your callback opens popovers,
-> fills inputs, or otherwise mutates UI state, pass `{ parallel: false }` to avoid overlapping interactions.
+> **`map` + UI interactions:** `map` defaults to `concurrency: 'parallel'`. If your callback opens popovers,
+> fills inputs, or otherwise mutates UI state, pass `{ concurrency: 'sequential' }` (or `'synchronized'` if you need lock-step navigation with serialized work).
+
+The legacy `{ parallel: true | false }` option still works but is deprecated; prefer `concurrency`.
 
 ### `filter` vs `findRows`
 

--- a/docs/.vitepress/smartrow-signatures.json
+++ b/docs/.vitepress/smartrow-signatures.json
@@ -1,5 +1,20 @@
 [
   {
+    "name": "rowIndex?",
+    "signature": "rowIndex?: number",
+    "comment": "/** Optional row index (0-based) if known */"
+  },
+  {
+    "name": "tablePageIndex?",
+    "signature": "tablePageIndex?: number",
+    "comment": "/** Optional page index this row was found on (0-based) */"
+  },
+  {
+    "name": "table",
+    "signature": "table: TableResult<T>",
+    "comment": "/** Reference to the parent TableResult */"
+  },
+  {
     "name": "getCell",
     "signature": "getCell(column: string): Locator",
     "comment": "/**\n* Get a cell locator by column name.\n* @param column - Column name (case-sensitive)\n* @returns Locator for the cell\n* @example\n* const emailCell = row.getCell('Email');\n* await expect(emailCell).toHaveText('john@example.com');\n*/"

--- a/docs/.vitepress/tableconfig-signatures.json
+++ b/docs/.vitepress/tableconfig-signatures.json
@@ -1,1 +1,57 @@
-[]
+[
+  {
+    "name": "headerSelector?",
+    "signature": "headerSelector?: string | ((root: Locator) => Locator)",
+    "comment": "/** Selector for the table headers */"
+  },
+  {
+    "name": "rowSelector?",
+    "signature": "rowSelector?: string",
+    "comment": "/** Selector for the table rows */"
+  },
+  {
+    "name": "cellSelector?",
+    "signature": "cellSelector?: string | ((row: Locator) => Locator)",
+    "comment": "/** Selector for the cells within a row */"
+  },
+  {
+    "name": "maxPages?",
+    "signature": "maxPages?: number",
+    "comment": "/** Number of pages to scan for verification */"
+  },
+  {
+    "name": "concurrency?",
+    "signature": "concurrency?: RowIterationMode",
+    "comment": "/**\n* Default concurrency strategy for iteration methods.\n* Can be overridden by the options passed to forEach, map, or filter.\n*/"
+  },
+  {
+    "name": "headerTransformer?",
+    "signature": "headerTransformer?: (args: { text: string, index: number, locator: Locator, seenHeaders: Set<string> }) => string | Promise<string>",
+    "comment": "/** Hook to rename columns dynamically */"
+  },
+  {
+    "name": "autoScroll?",
+    "signature": "autoScroll?: boolean",
+    "comment": "/** Automatically scroll to table on init */"
+  },
+  {
+    "name": "debug?",
+    "signature": "debug?: DebugConfig",
+    "comment": "/** Debug options for development and troubleshooting */"
+  },
+  {
+    "name": "onReset?",
+    "signature": "onReset?: (context: TableContext) => Promise<void>",
+    "comment": "/** Reset hook */"
+  },
+  {
+    "name": "strategies?",
+    "signature": "strategies?: TableStrategies",
+    "comment": "/** All interaction strategies */"
+  },
+  {
+    "name": "columnOverrides?",
+    "signature": "columnOverrides?: Partial<Record<keyof T, ColumnOverride<T[keyof T]>>>",
+    "comment": "/**\n* Unified interface for reading and writing data to specific columns.\n* Overrides both default extraction (toJSON) and filling (smartFill) logic.\n*/"
+  }
+]

--- a/docs/.vitepress/tableresult-signatures.json
+++ b/docs/.vitepress/tableresult-signatures.json
@@ -27,11 +27,11 @@
   {
     "name": "getRow",
     "signature": "getRow: (\n  filters: Record<string, FilterValue>,\n  options?: { exact?: boolean }",
-    "comment": "/**\n* Finds a row by filters on the current page only. Returns immediately (sync).\n* Throws error if table is not initialized.\n*/"
+    "comment": "/**\n* Finds a row by filters on the current page only. Returns immediately (sync).\n* Throws error if table is not initialized.\n* @note The returned SmartRow may have `rowIndex` as 0 when the match is not the first row.\n* Use getRowByIndex(index) when you need a known index (e.g. for bringIntoView()).\n*/"
   },
   {
     "name": "getRowByIndex",
-    "signature": "getRowByIndex(index: number): SmartRow",
+    "signature": "getRowByIndex: (\n  index: number\n  ) => SmartRow",
     "comment": "/**\n* Gets a row by 0-based index on the current page.\n* Throws error if table is not initialized.\n* @param index 0-based row index\n*/"
   },
   {
@@ -42,22 +42,7 @@
   {
     "name": "findRows",
     "signature": "findRows: (\n  filters?: Record<string, FilterValue>,\n  options?: { exact?: boolean, maxPages?: number }",
-    "comment": "/**\n* ASYNC: Searches for all matching rows across pages using pagination.\n* Auto-initializes the table if not already initialized.\n* @param filters - The filter criteria to match\n* @param options - Search options including exact match and max pages\n*/"
-  },
-  {
-    "name": "forEach",
-    "signature": "forEach(\n  callback: (ctx: RowIterationContext<T>) => void | Promise<void>,\n  options?: RowIterationOptions\n): Promise<void>",
-    "comment": "/**\n* Iterate every row across all pages. Call stop() in callback to end early.\n* @param callback - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, parallel, dedupe, useBulkPagination\n*/"
-  },
-  {
-    "name": "map",
-    "signature": "map<R>(\n  callback: (ctx: RowIterationContext<T>) => R | Promise<R>,\n  options?: RowIterationOptions\n): Promise<R[]>",
-    "comment": "/**\n* Transform every row across all pages into a value. Returns flat array.\n* @param callback - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, parallel, dedupe, useBulkPagination\n*/"
-  },
-  {
-    "name": "filter",
-    "signature": "filter(\n  predicate: (ctx: RowIterationContext<T>) => boolean | Promise<boolean>,\n  options?: RowIterationOptions\n): Promise<SmartRowArray<T>>",
-    "comment": "/**\n* Filter rows across all pages by async predicate. Returns SmartRowArray.\n* @param predicate - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, parallel, dedupe, useBulkPagination\n*/"
+    "comment": "/**\n* ASYNC: Searches for all matching rows across pages using pagination.\n* Auto-initializes the table if not already initialized.\n* @param filters - The filter criteria to match (omit or pass {} for all rows)\n* @param options - Search options including exact match and max pages\n*/"
   },
   {
     "name": "scrollToColumn",
@@ -75,13 +60,33 @@
     "comment": "/**\n* Revalidates the table's structure (headers, columns) without resetting pagination or state.\n* Useful when columns change visibility or order dynamically.\n*/"
   },
   {
+    "name": "forEach",
+    "signature": "forEach(\n  callback: (ctx: RowIterationContext<T>) => void | Promise<void>,\n  options?: RowIterationOptions\n  ): Promise<void>",
+    "comment": "/**\n* Iterates every row across all pages, calling the callback for side effects.\n* Execution is sequential by default (safe for interactions like clicking/filling).\n* Call `stop()` in the callback to end iteration early.\n*\n* @param callback - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)\n*\n* @example\n* await table.forEach(async ({ row, stop }) => {\n*   if (await row.getCell('Status').innerText() === 'Done') stop();\n*   await row.getCell('Checkbox').click();\n* });\n*/"
+  },
+  {
+    "name": "map",
+    "signature": "map<R>(\n  callback: (ctx: RowIterationContext<T>) => R | Promise<R>,\n  options?: RowIterationOptions\n  ): Promise<R[]>",
+    "comment": "/**\n* Transforms every row across all pages into a value. Returns a flat array.\n* Execution is parallel within each page by default (safe for reads).\n* Call `stop()` to halt after the current page finishes.\n*\n* > **⚠️ UI Interactions:** `map` defaults to `concurrency: 'parallel'`. If your callback opens popovers,\n* > fills inputs, or otherwise mutates UI state, pass `concurrency: 'sequential'` (or `'synchronized'`\n* > when navigation must stay lock-step) to avoid overlapping interactions.\n*\n* @param callback - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)\n*\n* @example\n* // Data extraction — parallel is safe\n* const emails = await table.map(({ row }) => row.getCell('Email').innerText());\n*\n* @example\n* // UI interactions — use sequential (or synchronized) concurrency\n* const assignees = await table.map(async ({ row }) => {\n*   await row.getCell('Assignee').locator('button').click();\n*   const name = await page.locator('.popover .name').innerText();\n*   await page.keyboard.press('Escape');\n*   return name;\n* }, { concurrency: 'sequential' });\n*/"
+  },
+  {
+    "name": "filter",
+    "signature": "filter(\n  predicate: (ctx: RowIterationContext<T>) => boolean | Promise<boolean>,\n  options?: RowIterationOptions\n  ): Promise<SmartRowArray<T>>",
+    "comment": "/**\n* Filters rows across all pages by an async predicate. Returns a SmartRowArray.\n* Rows are returned as-is — call `bringIntoView()` on each if needed.\n* Execution is sequential by default.\n*\n* @param predicate - Function receiving { row, rowIndex, stop }\n* @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)\n*\n* @example\n* const active = await table.filter(async ({ row }) =>\n*   await row.getCell('Status').innerText() === 'Active'\n* );\n*/"
+  },
+  {
     "name": "sorting",
     "signature": "sorting: {\n  apply(columnName: string, direction: 'asc' | 'desc'): Promise<void>;\n  getState(columnName: string): Promise<'asc' | 'desc' | 'none'>;\n  }",
     "comment": "/**\n* Gets the current sort state of a column using the configured sorting strategy.\n* @param columnName The name of the column to check.\n* @returns A promise that resolves to 'asc', 'desc', or 'none'.\n*/"
   },
   {
     "name": "generateConfig",
-    "signature": "generateConfig(): Promise<void>",
-    "comment": "/**\n* Generate an AI-friendly configuration prompt for debugging.\n* Outputs table HTML and TypeScript definitions. Throws Error containing the prompt.\n*/"
+    "signature": "generateConfig: () => Promise<void>",
+    "comment": "/**\n* Generate an AI-friendly configuration prompt for debugging.\n* Outputs table HTML and TypeScript definitions to help AI assistants generate config.\n* Automatically throws an Error containing the prompt.\n*/"
+  },
+  {
+    "name": "generateConfigPrompt",
+    "signature": "generateConfigPrompt: () => Promise<void>",
+    "comment": "/**\n* @deprecated Use `generateConfig()` instead. Will be removed in v7.0.0.\n*/"
   }
 ]

--- a/docs/.vitepress/tablestrategies-signatures.json
+++ b/docs/.vitepress/tablestrategies-signatures.json
@@ -1,5 +1,45 @@
 [
   {
+    "name": "header?",
+    "signature": "header?: HeaderStrategy",
+    "comment": "/** Strategy for discovering/scanning headers */"
+  },
+  {
+    "name": "navigation?",
+    "signature": "navigation?: NavigationPrimitives",
+    "comment": "/** Primitive navigation functions (goUp, goDown, goLeft, goRight, goHome) */"
+  },
+  {
+    "name": "fill?",
+    "signature": "fill?: FillStrategy",
+    "comment": "/** Strategy for filling form inputs */"
+  },
+  {
+    "name": "pagination?",
+    "signature": "pagination?: PaginationStrategy",
+    "comment": "/** Strategy for paginating through data */"
+  },
+  {
+    "name": "sorting?",
+    "signature": "sorting?: SortingStrategy",
+    "comment": "/** Strategy for sorting columns */"
+  },
+  {
+    "name": "dedupe?",
+    "signature": "dedupe?: DedupeStrategy",
+    "comment": "/** Strategy for deduplicating rows during iteration/scrolling */"
+  },
+  {
+    "name": "getCellLocator?",
+    "signature": "getCellLocator?: GetCellLocatorFn",
+    "comment": "/** Function to get a cell locator */"
+  },
+  {
+    "name": "getActiveCell?",
+    "signature": "getActiveCell?: GetActiveCellFn",
+    "comment": "/** Function to get the currently active/focused cell */"
+  },
+  {
     "name": "filter?",
     "signature": "filter?: FilterStrategy",
     "comment": "/**\n* Strategy for filtering rows. If present, FilterEngine will delegate filter application\n* to this pluggable strategy.\n*/"

--- a/docs/api/table-methods.md
+++ b/docs/api/table-methods.md
@@ -200,7 +200,7 @@ findRows(
 
 ### Parameters
 
-- `filters` - The filter criteria to match
+- `filters` - The filter criteria to match (omit or pass {} for all rows)
 - `options` - Search options including exact match and max pages
 
 <!-- /api-signature: findRows -->
@@ -255,7 +255,7 @@ forEach(
 ### Parameters
 
 - `callback` - Function receiving { row, rowIndex, stop }
-- `options` - maxPages, parallel, dedupe, useBulkPagination
+- `options` - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)
 
 <!-- /api-signature: forEach -->
 
@@ -278,7 +278,7 @@ await table.forEach(async ({ row, rowIndex, stop }) => {
 Transform every row across all pages into a value. Returns a flat array. Execution is parallel within each page by default (safe for reads). Call `stop()` to halt after the current page finishes.
 
 > [!WARNING]
-> `map` defaults to `parallel: true`. If your callback opens popovers, fills inputs, or mutates UI state, pass `{ parallel: false }`.
+> `map` defaults to `concurrency: 'parallel'`. If your callback opens popovers, fills inputs, or mutates UI state, pass `{ concurrency: 'sequential' }` or `{ concurrency: 'synchronized' }` as appropriate.
 
 <!-- api-signature: map -->
 
@@ -297,13 +297,13 @@ map<R>(
 // Data extraction — parallel is safe
 const emails = await table.map(({ row }) => row.getCell('Email').innerText());
 
-// UI interactions — use parallel: false
+// UI interactions — use sequential (or synchronized) concurrency
 const assignees = await table.map(async ({ row }) => {
   await row.getCell('Assignee').locator('button').click();
   const name = await page.locator('.popover .name').innerText();
   await page.keyboard.press('Escape');
   return name;
-}, { parallel: false });
+}, { concurrency: 'sequential' });
 ```
 
 [Back to Top](#table-methods)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rickcedwhat/playwright-smart-table",
-  "version": "6.7.9",
+  "version": "6.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rickcedwhat/playwright-smart-table",
-      "version": "6.7.9",
+      "version": "6.8.0",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rickcedwhat/playwright-smart-table",
-  "version": "6.7.9",
+  "version": "6.8.0",
   "description": "Smart, column-aware table interactions for Playwright",
   "author": "Cedrick Catalan",
   "license": "MIT",

--- a/scripts/generate-all-api-docs.mjs
+++ b/scripts/generate-all-api-docs.mjs
@@ -18,8 +18,10 @@ const typesContent = fs.readFileSync(typesPath, 'utf-8');
 
 // Extract multiple interfaces
 const interfaces = {
-    TableResult: /export interface TableResult<T = any> \{([\s\S]*?)\n\}/,
-    TableConfig: /export interface TableConfig \{([\s\S]*?)\n\}/,
+    // TableResult extends AsyncIterable — keep regex in sync with src/types.ts declaration line.
+    TableResult:
+        /export interface TableResult<T = any> extends AsyncIterable<\{ row: SmartRow<T>; rowIndex: number \}> \{([\s\S]*?)\n\}/,
+    TableConfig: /export interface TableConfig<T = any> \{([\s\S]*?)\n\}/,
     SmartRow: /export type SmartRow<T = any> = Locator & \{([\s\S]*?)\n\};/,
     TableStrategies: /export interface TableStrategies \{([\s\S]*?)\n\}/
 };
@@ -48,6 +50,9 @@ function extractMethods(content, interfaceName) {
         if (line.startsWith('/**')) {
             inComment = true;
             currentComment = [line];
+            if (line.endsWith('*/')) {
+                inComment = false;
+            }
             continue;
         }
         if (inComment) {
@@ -59,6 +64,29 @@ function extractMethods(content, interfaceName) {
         }
 
         if (!line || line.startsWith('//')) continue;
+
+        // Multi-line method: forEach( / map<R>( / filter( — first line has no `name:` before `(`
+        const multiMethod = line.match(/^([a-zA-Z_]\w*)(<[^>]+>)?\(\s*$/);
+        if (multiMethod && !currentSignature) {
+            const methodName = multiMethod[1];
+            currentSignature = line;
+            let parenDepth =
+                (line.match(/\(/g) || []).length - (line.match(/\)/g) || []).length;
+            while (parenDepth > 0 && i + 1 < lines.length) {
+                i++;
+                const cont = lines[i].trim();
+                currentSignature += '\n  ' + cont;
+                parenDepth += (cont.match(/\(/g) || []).length - (cont.match(/\)/g) || []).length;
+            }
+            methods.push({
+                name: methodName,
+                signature: currentSignature,
+                comment: currentComment.join('\n')
+            });
+            currentSignature = '';
+            currentComment = [];
+            continue;
+        }
 
         if (line.includes(':') && !currentSignature) {
             currentSignature = line;

--- a/src/typeContext.ts
+++ b/src/typeContext.ts
@@ -541,6 +541,9 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Execution is sequential by default (safe for interactions like clicking/filling).
    * Call \`stop()\` in the callback to end iteration early.
    *
+   * @param callback - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (\`parallel\` is deprecated; use \`concurrency\`)
+   *
    * @example
    * await table.forEach(async ({ row, stop }) => {
    *   if (await row.getCell('Status').innerText() === 'Done') stop();
@@ -557,22 +560,25 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Execution is parallel within each page by default (safe for reads).
    * Call \`stop()\` to halt after the current page finishes.
    *
-   * > **⚠️ UI Interactions:** \`map\` defaults to \`parallel: true\`. If your callback opens popovers,
-   * > fills inputs, or otherwise mutates UI state, pass \`{ parallel: false }\` to avoid concurrent
-   * > interactions interfering with each other.
+   * > **⚠️ UI Interactions:** \`map\` defaults to \`concurrency: 'parallel'\`. If your callback opens popovers,
+   * > fills inputs, or otherwise mutates UI state, pass \`concurrency: 'sequential'\` (or \`'synchronized'\`
+   * > when navigation must stay lock-step) to avoid overlapping interactions.
+   *
+   * @param callback - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (\`parallel\` is deprecated; use \`concurrency\`)
    *
    * @example
    * // Data extraction — parallel is safe
    * const emails = await table.map(({ row }) => row.getCell('Email').innerText());
    *
    * @example
-   * // UI interactions — must use parallel: false
+   * // UI interactions — use sequential (or synchronized) concurrency
    * const assignees = await table.map(async ({ row }) => {
    *   await row.getCell('Assignee').locator('button').click();
    *   const name = await page.locator('.popover .name').innerText();
    *   await page.keyboard.press('Escape');
    *   return name;
-   * }, { parallel: false });
+   * }, { concurrency: 'sequential' });
    */
   map<R>(
     callback: (ctx: RowIterationContext<T>) => R | Promise<R>,
@@ -583,6 +589,9 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Filters rows across all pages by an async predicate. Returns a SmartRowArray.
    * Rows are returned as-is — call \`bringIntoView()\` on each if needed.
    * Execution is sequential by default.
+   *
+   * @param predicate - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (\`parallel\` is deprecated; use \`concurrency\`)
    *
    * @example
    * const active = await table.filter(async ({ row }) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -541,6 +541,9 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Execution is sequential by default (safe for interactions like clicking/filling).
    * Call `stop()` in the callback to end iteration early.
    *
+   * @param callback - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)
+   *
    * @example
    * await table.forEach(async ({ row, stop }) => {
    *   if (await row.getCell('Status').innerText() === 'Done') stop();
@@ -557,22 +560,25 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Execution is parallel within each page by default (safe for reads).
    * Call `stop()` to halt after the current page finishes.
    *
-   * > **⚠️ UI Interactions:** `map` defaults to `parallel: true`. If your callback opens popovers,
-   * > fills inputs, or otherwise mutates UI state, pass `{ parallel: false }` to avoid concurrent
-   * > interactions interfering with each other.
+   * > **⚠️ UI Interactions:** `map` defaults to `concurrency: 'parallel'`. If your callback opens popovers,
+   * > fills inputs, or otherwise mutates UI state, pass `concurrency: 'sequential'` (or `'synchronized'`
+   * > when navigation must stay lock-step) to avoid overlapping interactions.
+   *
+   * @param callback - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)
    *
    * @example
    * // Data extraction — parallel is safe
    * const emails = await table.map(({ row }) => row.getCell('Email').innerText());
    *
    * @example
-   * // UI interactions — must use parallel: false
+   * // UI interactions — use sequential (or synchronized) concurrency
    * const assignees = await table.map(async ({ row }) => {
    *   await row.getCell('Assignee').locator('button').click();
    *   const name = await page.locator('.popover .name').innerText();
    *   await page.keyboard.press('Escape');
    *   return name;
-   * }, { parallel: false });
+   * }, { concurrency: 'sequential' });
    */
   map<R>(
     callback: (ctx: RowIterationContext<T>) => R | Promise<R>,
@@ -583,6 +589,9 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    * Filters rows across all pages by an async predicate. Returns a SmartRowArray.
    * Rows are returned as-is — call `bringIntoView()` on each if needed.
    * Execution is sequential by default.
+   *
+   * @param predicate - Function receiving { row, rowIndex, stop }
+   * @param options - maxPages, concurrency, dedupe, useBulkPagination (`parallel` is deprecated; use `concurrency`)
    *
    * @example
    * const active = await table.filter(async ({ row }) =>


### PR DESCRIPTION
## Summary
Follow-up to merged #36: **version 6.8.0** and documentation / tooling updates that were not part of that PR.

- **CHANGELOG** for 6.8.0 (concurrency modes, Glide preset, Mutex/NavigationBarrier, SmartRow/runMap, doc generator fixes).
- **README** — iteration section documents `concurrency` (`parallel` / `sequential` / `synchronized`) and deprecates `parallel` in prose.
- **types.ts** — JSDoc on `forEach` / `map` / `filter` updated for `concurrency`.
- **docs/api/table-methods.md** + regenerated **VitePress signature JSON** via fixed `scripts/generate-all-api-docs.mjs` (TableResult/TableConfig regex, single-line JSDoc bug, multi-line method parsing).
- **package.json** + **package-lock.json** → `6.8.0`.

## Testing
- `npm run build`
- `npx vitest run` (107 unit tests)

Made with [Cursor](https://cursor.com)