### PR TITLE
fix(iteration): synchronized map deadlock (Mutex + NavigationBarrier)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build VitePress site
         run: npm run docs:build
 
+      - name: Verify VitePress nav/sidebar links
+        run: npm run docs:verify-links
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build Documentation
         run: npm run docs:build
 
+      - name: Verify VitePress nav/sidebar links
+        run: npm run docs:verify-links
+
       - name: Check for TODO/FIXME
         run: |
           if grep -r "TODO\|FIXME" src/ --exclude-dir=node_modules; then

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "update-all-api-signatures": "node scripts/update-all-api-signatures.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
+    "docs:verify-links": "node scripts/verify-vitepress-links.mjs",
     "build": "npm run generate-types && npm run generate-config-types && npm run generate-docs && npm run generate-all-api-docs && npm run update-all-api-signatures && tsc",
     "prepublishOnly": "npm run build",
     "clean-port": "lsof -ti:3000 | xargs kill -9 || true",

--- a/scripts/verify-vitepress-links.mjs
+++ b/scripts/verify-vitepress-links.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Verify VitePress themeConfig internal links (nav + sidebar) against the built site.
+ *
+ * Fragment targets (#anchors) are checked against id="..." in the generated HTML — the same
+ * output users get from `vitepress build`, so this stays deterministic.
+ *
+ * Usage:
+ *   npm run docs:build && npm run docs:verify-links
+ *
+ * Env:
+ *   DOCS_DIST  — override path to dist (default: docs/.vitepress/dist)
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+const configPath = path.join(root, 'docs/.vitepress/config.mts');
+const distRoot = process.env.DOCS_DIST
+    ? path.resolve(process.env.DOCS_DIST)
+    : path.join(root, 'docs/.vitepress/dist');
+
+function resolveHtmlFile(pathname) {
+    const normalized = pathname.replace(/\/+$/, '') || '/';
+    if (normalized === '/') {
+        return path.join(distRoot, 'index.html');
+    }
+    const asHtml = path.join(distRoot, `${normalized}.html`);
+    if (fs.existsSync(asHtml)) {
+        return asHtml;
+    }
+    const asIndex = path.join(distRoot, normalized, 'index.html');
+    if (fs.existsSync(asIndex)) {
+        return asIndex;
+    }
+    return null;
+}
+
+function collectElementIds(html) {
+    const ids = new Set();
+    const re = /\bid="([^"]+)"/g;
+    let m;
+    while ((m = re.exec(html)) !== null) {
+        ids.add(m[1]);
+    }
+    return ids;
+}
+
+function extractInternalLinksFromConfig(source) {
+    const out = new Set();
+    const re = /\blink:\s*['"](\/[^'"]*)['"]/g;
+    let m;
+    while ((m = re.exec(source)) !== null) {
+        const raw = m[1];
+        if (raw.startsWith('//')) continue;
+        out.add(raw);
+    }
+    return [...out];
+}
+
+function main() {
+    if (!fs.existsSync(distRoot)) {
+        console.error(`❌ Dist not found: ${distRoot}`);
+        console.error('   Run: npm run docs:build');
+        process.exit(1);
+    }
+
+    if (!fs.existsSync(configPath)) {
+        console.error(`❌ Config not found: ${configPath}`);
+        process.exit(1);
+    }
+
+    const configSource = fs.readFileSync(configPath, 'utf8');
+    const links = extractInternalLinksFromConfig(configSource);
+
+    const failures = [];
+
+    for (const link of links) {
+        const [pathPart, fragment] = link.split('#');
+        const htmlPath = resolveHtmlFile(pathPart);
+
+        if (!htmlPath) {
+            failures.push({ link, reason: `no HTML for path "${pathPart}"` });
+            continue;
+        }
+
+        if (!fragment) {
+            continue;
+        }
+
+        const html = fs.readFileSync(htmlPath, 'utf8');
+        const ids = collectElementIds(html);
+        if (!ids.has(fragment)) {
+            const hint = suggestId(ids, fragment);
+            failures.push({
+                link,
+                reason: `missing id="${fragment}" in ${path.relative(root, htmlPath)}${hint}`
+            });
+        }
+    }
+
+    if (failures.length > 0) {
+        console.error('❌ VitePress link verification failed:\n');
+        for (const f of failures) {
+            console.error(`   • ${f.link}`);
+            console.error(`     ${f.reason}\n`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`✅ Verified ${links.length} internal nav/sidebar link(s) under ${path.relative(root, distRoot)}`);
+}
+
+/** If fragment missing, show a few similar ids (typos). */
+function suggestId(ids, fragment) {
+    const lower = fragment.toLowerCase();
+    const similar = [...ids].filter(
+        (id) =>
+            id.includes(lower) ||
+            lower.includes(id) ||
+            levenshtein(id, fragment) <= 2
+    );
+    if (similar.length === 0) return '';
+    const sample = similar.slice(0, 8).join(', ');
+    return ` (similar ids: ${sample}${similar.length > 8 ? ', …' : ''})`;
+}
+
+function levenshtein(a, b) {
+    if (a.length < b.length) [a, b] = [b, a];
+    const row = Array.from({ length: b.length + 1 }, (_, i) => i);
+    for (let i = 1; i <= a.length; i++) {
+        let prev = i - 1;
+        row[0] = i;
+        for (let j = 1; j <= b.length; j++) {
+            const tmp = row[j];
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            row[j] = Math.min(row[j] + 1, row[j - 1] + 1, prev + cost);
+            prev = tmp;
+        }
+    }
+    return row[b.length];
+}
+
+main();

--- a/src/engine/tableIteration.ts
+++ b/src/engine/tableIteration.ts
@@ -52,7 +52,10 @@ export async function runMap<T, R>(
                       options.parallel === false ? 'sequential' : 
                       env.config.concurrency || defaultMode);
   const useBarrier = concurrency !== 'sequential';
-  const useMutex = concurrency !== 'parallel';
+  // Mutex must not pair with the navigation barrier: synchronized mode needs every row
+  // to enter barrier.sync concurrently; serializing callbacks here deadlocks (first row waits
+  // for batchSize peers that never reach the barrier).
+  const useMutex = concurrency === 'sequential';
   const useBulk = options.useBulkPagination ?? false;
   const tracker = new ElementTracker(label);
 

--- a/tests/unit/tableIteration.synchronized.test.ts
+++ b/tests/unit/tableIteration.synchronized.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { TableIterationEnv } from '../../src/engine/tableIteration';
+import { runMap } from '../../src/engine/tableIteration';
+import type { FinalTableConfig } from '../../src/types';
+
+vi.mock('../../src/utils/elementTracker', () => ({
+  ElementTracker: class {
+    private _called = false;
+    async getUnseenIndices(locators: any) {
+      if (this._called) return [];
+      this._called = true;
+      const rows = await locators.all();
+      return rows.map((_: any, i: number) => i);
+    }
+    async cleanup() {}
+  },
+}));
+
+/**
+ * Two fake rows whose toJSON participates in the same NavigationBarrier as real SmartRow
+ * (first column sync). Under mutex+barrier this deadlocks; synchronized must complete.
+ */
+function makeBarrierEnv(rowCount: number): TableIterationEnv<any> {
+  const config: FinalTableConfig = {
+    rowSelector: 'tr',
+    headerSelector: 'th',
+    cellSelector: 'td',
+    maxPages: 1,
+    autoScroll: false,
+    headerTransformer: ({ text }: any) => text,
+    onReset: async () => {},
+    strategies: {},
+    debug: { logLevel: 'none' },
+  } as any;
+
+  return {
+    getRowLocators: () =>
+      ({
+        all: async () => Array.from({ length: rowCount }, (_, i) => ({ _index: i })),
+      }) as any,
+    getMap: () => new Map([['A', 0]]),
+    advancePage: async () => false,
+    makeSmartRow: (_loc: any, _map: any, idx: number, _page: number | undefined, barrier: any) =>
+      ({
+        rowIndex: idx,
+        toJSON: async () => {
+          if (barrier) {
+            await barrier.sync(0, async () => {});
+          }
+          return { row: idx };
+        },
+      }) as any,
+    createSmartRowArray: (arr: any[]) => arr as any,
+    config,
+    getPage: () => ({}) as any,
+  };
+}
+
+describe('runMap synchronized + NavigationBarrier', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('completes with multiple rows (no mutex/barrier deadlock)', async () => {
+    const env = makeBarrierEnv(3);
+    const results = await runMap(
+      env,
+      async ({ row }) => (row as any).toJSON(),
+      { concurrency: 'synchronized' }
+    );
+    expect(results).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Problem

With `concurrency: 'synchronized'`, row iteration used both:

- **NavigationBarrier** — `toJSON` / `_navigateToCell` waits until every row in the batch reaches the same column sync.
- **Mutex** — any mode other than `parallel` serialized row callbacks.

The first row blocked on the barrier forever because the mutex prevented other rows from ever entering `barrier.sync`. This showed up as an indefinite hang right after the first `_navigateToCell` log (e.g. column index 0).

## Change

Use the row callback mutex only for `sequential` mode. `synchronized` keeps lock-step navigation via the barrier while allowing all rows in the batch to run until they meet at the barrier.

## Test

- `tests/unit/tableIteration.synchronized.test.ts` — fake rows call `barrier.sync` like real SmartRow navigation; would deadlock under the old mutex pairing.

Made with [Cursor](https://cursor.com)