### PR TITLE
chore(ci): Dependabot group for vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       - "dependencies"
       - "auto-approve"
     rebase-strategy: "auto"
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Groups `vitest` and `@vitest/*` into a single npm version-update PR so peer versions stay aligned (avoids ERESOLVE when e.g. `@vitest/ui` bumps ahead of `vitest`).

Made with [Cursor](https://cursor.com)