### PR TITLE
ci: drop global npm@latest upgrade in workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,9 +32,6 @@ jobs:
           node-version: 20
           cache: npm
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -19,9 +19,6 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install Dependencies
         run: npm ci
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,9 +19,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Install Dependencies
         run: npm install
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Check if version changed
         id: check_version
         run: |


### PR DESCRIPTION
## Problem
`npm install -g npm@latest` after setup-node was failing on hosted runners (e.g. missing `promise-retry` in `@npmcli/arborist`), blocking `npm install` in PR checks.

## Change
Remove the redundant global npm upgrade in all four workflows that used it. Use the npm version bundled with each Node version from `actions/setup-node`.

Made with [Cursor](https://cursor.com)