### PR TITLE
ci: faster Playwright runs on GitHub Actions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,8 @@
 // playwright.config.ts
 import { defineConfig } from '@playwright/test';
 
+const isCI = !!process.env.CI;
+
 export default defineConfig({
   // Look for test files in the "tests" directory, relative to this configuration file.
   testDir: './tests',
@@ -10,24 +12,21 @@ export default defineConfig({
   fullyParallel: true,
 
   // Fail the build on CI if you accidentally left test.only in the source code.
-  forbidOnly: !!process.env.CI,
+  forbidOnly: isCI,
 
   // Retry on CI only.
-  retries: process.env.CI ? 2 : 0,
+  retries: isCI ? 2 : 0,
 
-  // Opt out of parallel tests on CI.
-  workers: process.env.CI ? 1 : undefined,
+  // CI: use 2 workers on typical 2-vCPU GHA runners (was 1, which serialized everything).
+  workers: isCI ? 2 : undefined,
 
   // Reporter to use
   reporter: 'html',
 
   use: {
-    // Collect trace when retrying the failed test.
-    // Setting to 'on' forces it for every run (useful for debugging now).
-    trace: 'on',
-
-    // Record video for every run
-    video: 'on',
+    // Local: full trace/video for debugging. CI: keep artifacts only on failure (much faster).
+    trace: isCI ? 'retain-on-failure' : 'on',
+    video: isCI ? 'retain-on-failure' : 'on',
 
     // Take screenshot on failure
     screenshot: 'only-on-failure',
@@ -39,14 +38,14 @@ export default defineConfig({
       command: 'npm run dev',
       cwd: 'playground',
       port: 3000,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: !isCI,
       timeout: 120 * 1000, // Increase to 2 minutes for slow CI environments
     },
     {
       command: 'npm run dev',
       cwd: 'tests/apps/mui-datagrid',
       port: 3050,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: !isCI,
       timeout: 120 * 1000,
     },
   ],

--- a/tests/debug-mode.spec.ts
+++ b/tests/debug-mode.spec.ts
@@ -1,6 +1,20 @@
 import { test, expect } from '@playwright/test';
 import { useTable } from '../src/index';
 
+/** Shorter delays in CI so debug.slow tests stay valid but do not dominate runtime. */
+const isCI = !!process.env.CI;
+const slow = {
+    uniformMs: isCI ? 80 : 500,
+    granularDefaultMs: isCI ? 120 : 800,
+    granularFindRowMs: isCI ? 25 : 100,
+    findRowOnlyMs: isCI ? 100 : 600,
+    combinedUniformMs: isCI ? 40 : 200,
+};
+
+function minElapsedForDelay(ms: number): number {
+    return Math.max(15, Math.floor(ms * 0.85));
+}
+
 test.describe('Debug Mode', () => {
     test('No debug mode works normally (performance check)', async ({ page }) => {
         await page.goto('https://datatables.net/examples/data_sources/dom');
@@ -31,17 +45,16 @@ test.describe('Debug Mode', () => {
         const table = useTable(page.locator('#example'), {
             headerSelector: 'thead th',
             debug: {
-                slow: 500,  // 500ms delay
+                slow: slow.uniformMs,
                 logLevel: 'info'
             }
         });
 
-        // Init should take at least 500ms due to delay
         const start = Date.now();
         await table.init();
         const elapsed = Date.now() - start;
 
-        expect(elapsed).toBeGreaterThanOrEqual(450); // Small margin for error
+        expect(elapsed).toBeGreaterThanOrEqual(minElapsedForDelay(slow.uniformMs));
     });
 
     test('Granular delays work', async ({ page }) => {
@@ -52,19 +65,18 @@ test.describe('Debug Mode', () => {
             headerSelector: 'thead th',
             debug: {
                 slow: {
-                    default: 800,
-                    findRow: 100
+                    default: slow.granularDefaultMs,
+                    findRow: slow.granularFindRowMs
                 },
                 logLevel: 'info'
             }
         });
 
-        // Init should use default delay (800ms)
         const start = Date.now();
         await table.init();
         const elapsed = Date.now() - start;
 
-        expect(elapsed).toBeGreaterThanOrEqual(750);
+        expect(elapsed).toBeGreaterThanOrEqual(minElapsedForDelay(slow.granularDefaultMs));
     });
 
     test('FindRow with delays', async ({ page }) => {
@@ -75,7 +87,7 @@ test.describe('Debug Mode', () => {
             headerSelector: 'thead th',
             debug: {
                 slow: {
-                    findRow: 600
+                    findRow: slow.findRowOnlyMs
                 },
                 logLevel: 'info'
             }
@@ -83,12 +95,11 @@ test.describe('Debug Mode', () => {
 
         await table.init();
 
-        // FindRow should take at least 600ms
         const start = Date.now();
         await table.findRow({ Name: 'Airi Satou' });
         const elapsed = Date.now() - start;
 
-        expect(elapsed).toBeGreaterThanOrEqual(550);
+        expect(elapsed).toBeGreaterThanOrEqual(minElapsedForDelay(slow.findRowOnlyMs));
     });
 
     test('Combined debug features', async ({ page }) => {
@@ -98,8 +109,8 @@ test.describe('Debug Mode', () => {
         const table = useTable(page.locator('#example'), {
             headerSelector: 'thead th',
             debug: {
-                slow: 200,                   // 200ms delays
-                logLevel: 'info'             // Info-level logging
+                slow: slow.combinedUniformMs,
+                logLevel: 'info'
             }
         });
 


### PR DESCRIPTION
## Summary
- **Trace / video:** In CI, use `retain-on-failure` instead of recording for every test (major time + disk savings).
- **Workers:** Use `2` workers on CI (typical 2 vCPU GHA runners) instead of serializing the whole suite.
- **debug.slow tests:** When `CI` is set, use shorter delays in `tests/debug-mode.spec.ts` with scaled assertions so behavior is still covered without dominating runtime.

Local runs are unchanged (full trace/video, original slow timings).

Made with [Cursor](https://cursor.com)