### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,6 @@ jobs:
       - name: Publish to NPM
         if: steps.check_version.outputs.changed == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       
       - name: Prepare changelog for GitHub Release
         if: steps.check_version.outputs.changed == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ html/
 /.playground.pid
 /coverage/
 /.cache/
+/.local/
 /.idea/
 *.log
 .nyc_output/


### PR DESCRIPTION
## Summary
- Remove the explicit `NPM_TOKEN` publish env so npm can use the configured Trusted Publisher/OIDC flow.
- Ignore the local `.local/` runbook folder used for private maintenance notes.

## Test plan
- Not run locally; this change is exercised by the publish workflow after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NPM publishing workflow authentication configuration
  * Added local directory to gitignore

<!-- end of auto-generated comment: release notes by coderabbit.ai -->