### PR TITLE
Align CI on Node 24 for trusted publishing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Setup Pages

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Check if version changed
@@ -38,29 +38,16 @@ jobs:
             echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Cache Playwright
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
       - name: Install Dependencies
+        if: steps.check_version.outputs.changed == 'true'
         run: npm ci
 
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      - name: Install Sub-App Dependencies
-        run: node scripts/install-apps.mjs
-
-      - name: Run Tests
-        run: npm test
+      - name: Build Project
+        if: steps.check_version.outputs.changed == 'true'
+        run: npm run build
 
       - name: Test Packaging
+        if: steps.check_version.outputs.changed == 'true'
         run: |
           chmod +x scripts/test-packaging.sh
           ./scripts/test-packaging.sh

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://rickcedwhat.github.io/playwright-smart-table/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rickcedwhat/playwright-smart-table.git"
+    "url": "git+https://github.com/rickcedwhat/playwright-smart-table.git"
   },
   "bugs": {
     "url": "https://github.com/rickcedwhat/playwright-smart-table/issues"


### PR DESCRIPTION
## Summary
- Run GitHub workflows on Node 24 so npm Trusted Publishing uses a supported npm CLI version.
- Slim the publish workflow to install, build, verify packaging, and publish instead of rerunning full browser tests after PR checks.
- Normalize `repository.url` to npm's canonical GitHub URL format for Trusted Publishing matching.

## Test plan
- Workflow YAML lint diagnostics are clean.
- Publish workflow will validate the trusted publishing path after merge.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to Node.js v24 across CI/CD pipelines
  * Optimized publishing workflow for enhanced efficiency
  * Updated repository metadata format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->