### PR TITLE
docs: simplify onboarding flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,7 @@
   // ✅ Safe for popover interactions
   await table.map(async ({ row }) => { ... }, { parallel: false });
   ```
+  > Superseded in v6.8.0 by `concurrency: 'parallel' | 'sequential' | 'synchronized'`; `parallel` was removed in v6.9.0.
 
 ---
 
@@ -250,7 +251,7 @@
 ## [6.4.0] - 2026-02-18
 
 ### ⚠️ Breaking Changes
-- **Removed `getRows`**: The deprecated `getRows` method has been removed. Use `findRows` or `iterateThroughTable` instead.
+- **Removed `getRows`**: The deprecated `getRows` method has been removed. At the time, migration targeted `findRows` or `iterateThroughTable`; in current versions use `findRows`, `map`, `forEach`, or `filter`.
 - **Removed `cellNavigation`**: The deprecated `cellNavigation` strategy type has been removed in favor of `navigation` primitives.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ const email = await row.locator('td').nth(emailIndex).textContent();
 const row = table.getRow({ Name: 'John Doe' });
 const email = await row.getCell('Email').textContent();
 
-// ✅ Auto-pagination across all pages
-const allEngineers = await table.findRows({ Department: 'Engineering' });
+// ✅ Pagination-aware when you raise maxPages
+const allEngineers = await table.findRows(
+  { Department: 'Engineering' },
+  { maxPages: 5 }
+);
 
 // ✅ Type-safe
 type Employee = { Name: string; Email: string; Department: string };
@@ -72,8 +75,8 @@ const row = table.getRow({ Name: 'John Doe' });
 // Access cells by column name
 const email = await row.getCell('Email').innerText();
 
-// Search across paginated tables
-const allActive = await table.findRows({ Status: 'Active' });
+// Search more than the current page by raising maxPages
+const allActive = await table.findRows({ Status: 'Active' }, { maxPages: 5 });
 ```
 
 ### Iterating Across Pages
@@ -163,9 +166,9 @@ const table = useTable(page.locator('#table'), {
 - 🎯 **Smart Locators** - Find rows by content, not position
 - 🧠 **Fuzzy Matching** - Smart suggestions for typos in column names
 - ⚡ **Smart Initialization** - Handles loading states and dynamic headers automatically
-- 📄 **Auto-Pagination** - Search across all pages automatically
+- 📄 **Pagination-aware search** - Scan beyond the current page when `maxPages` is increased
 - 🔍 **Column-Aware Access** - Access cells by column name
-- 🔁 **Iteration Methods** - `forEach`, `map`, `filter`, and `for await...of` across all pages
+- 🔁 **Iteration Methods** - `forEach`, `map`, `filter`, and `for await...of` across the configured page range
 - 🛠️ **Debug Mode** - Visual debugging with slow motion and logging
 - 🔌 **[Extensible Strategies](docs/concepts/strategies.md)** - Support any table implementation
 - 💪 **Type-Safe** - Full TypeScript support

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@
       - `iterateThroughTable` (use `forEach`/`map`/`filter` instead).
       - `getColumnValues` (use `map` instead).
  - [x] **Document `forEach`/`map`/`filter` in README**
- - [x] **JSDoc `@note` on `map`'s `parallel` default**
+ - [x] **JSDoc `@note` on `map`'s `concurrency: 'parallel'` default**
  - [x] **Add mutation testing (Stryker)**
     - **Purpose**: Measure test effectiveness beyond coverage by introducing mutation testing using Stryker for Vitest.
     - **Goal**: Run locally and optionally as a scheduled CI job; aim for a high mutation score (>=80–90%).

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -105,7 +105,8 @@ export default defineConfig({
                                 { text: 'reset()', link: '/api/table-methods#reset' },
                                 { text: 'revalidate()', link: '/api/table-methods#revalidate' },
                                 { text: 'sorting', link: '/api/table-methods#sorting' },
-                                { text: 'generateConfig()', link: '/api/table-methods#generateconfig' }
+                                { text: 'generateConfig()', link: '/api/table-methods#generateconfig' },
+                                { text: 'generateConfigPrompt()', link: '/api/table-methods#generateconfigprompt' }
                             ]
                         },
                         {
@@ -116,7 +117,8 @@ export default defineConfig({
                                 { text: 'getCell()', link: '/api/smart-row#getcell' },
                                 { text: 'toJSON()', link: '/api/smart-row#tojson' },
                                 { text: 'bringIntoView()', link: '/api/smart-row#bringintoview' },
-                                { text: 'smartFill()', link: '/api/smart-row#smartfill' }
+                                { text: 'smartFill()', link: '/api/smart-row#smartfill' },
+                                { text: 'wasFound()', link: '/api/smart-row#wasfound' }
                             ]
                         },
                         {
@@ -132,7 +134,8 @@ export default defineConfig({
                                 { text: 'Sorting', link: '/api/strategies#sorting-strategies' },
                                 { text: 'Fill', link: '/api/strategies#fill-strategy' },
                                 { text: 'Header', link: '/api/strategies#header-strategy' },
-                                { text: 'Cell locator', link: '/api/strategies#cell-locator-strategy' }
+                                { text: 'Cell locator', link: '/api/strategies#cell-locator-strategy' },
+                                { text: 'Viewport', link: '/api/strategies#viewport-strategy' }
                             ]
                         }
                     ]

--- a/docs/.vitepress/smartrow-signatures.json
+++ b/docs/.vitepress/smartrow-signatures.json
@@ -27,7 +27,7 @@
   {
     "name": "bringIntoView",
     "signature": "bringIntoView(): Promise<void>",
-    "comment": "/**\n* Scrolls/paginates to bring this row into view.\n* Only works if rowIndex is known (e.g., from getRowByIndex).\n* @throws Error if rowIndex is unknown\n*/"
+    "comment": "/**\n* Scrolls/paginates to bring this row into view.\n* Works when row position metadata is known (e.g., from getRowByIndex, findRow,\n* findRows, filter, or async iteration).\n* @throws Error if row position metadata is unknown\n*/"
   },
   {
     "name": "smartFill",

--- a/docs/advanced/typescript.md
+++ b/docs/advanced/typescript.md
@@ -43,9 +43,9 @@ const ids = await table.map<number>(async ({ row }) => parseInt(await row.getCel
 If you are writing custom strategies, you can use the `TableContext` type to understand what arguments are available.
 
 ```typescript
-import type { TableContext } from 'playwright-smart-table';
+import type { TableContext } from '@rickcedwhat/playwright-smart-table';
 
-const myStrategy = async ({ page, rootLocator }: TableContext) => {
+const myStrategy = async ({ page, root }: TableContext) => {
     // ...
 };
 ```
@@ -60,7 +60,7 @@ All major types are exported for your use:
 - `TableResult`
 
 ```typescript
-import type { SmartRow } from 'playwright-smart-table';
+import type { SmartRow } from '@rickcedwhat/playwright-smart-table';
 
 // Helper function
 async function activateUser(row: SmartRow) {

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,48 +1,48 @@
-<!-- NEEDS REVIEW -->
 # API Reference
 
-Welcome to the Playwright Smart Table API documentation. This library provides a powerful, type-safe way to interact with HTML tables in Playwright tests.
+Use the API reference when you already know the method, config option, or strategy you need. If you are still learning the library, start with [Getting Started](/guide/getting-started) or [Examples](/examples/).
 
-## Quick Navigation
+## Main References
 
-### Configuration
-- [**TableConfig**](/api/table-config) - Configure table selectors, strategies, and behavior
+- [TableConfig](/api/table-config): selectors, strategies, debug, pagination limits, and column overrides.
+- [Table Methods](/api/table-methods): `getRow`, `findRow`, `findRows`, `map`, `forEach`, sorting, reset, and more.
+- [SmartRow](/api/smart-row): row-level helpers like `getCell`, `toJSON`, `smartFill`, and `bringIntoView`.
+- [SmartRowArray](/api/smart-row-array): array returned by `findRows()` and `filter()`.
+- [Strategies](/api/strategies): built-in and custom pagination, sorting, header, cell, fill, and viewport behavior.
 
-### Core Methods
-- [**Table Methods**](/api/table-methods) - Methods for finding and interacting with rows
-- [**SmartRow**](/api/smart-row) - Methods available on row objects
-- [**Strategies**](/api/strategies) - Built-in and custom strategies
+## Quick Method Map
 
-## Basic Usage
+| Need | API |
+|---|---|
+| Configure selectors or behavior | [TableConfig](/api/table-config) |
+| Find rows and iterate pages | [Table Methods](/api/table-methods) |
+| Read or interact with a row | [SmartRow](/api/smart-row) |
+| Convert many rows to JSON | [SmartRowArray](/api/smart-row-array) |
+| Adapt custom table behavior | [Strategies](/api/strategies) |
+
+## Minimal Usage
 
 ```typescript
 import { useTable } from '@rickcedwhat/playwright-smart-table';
 
-const table = useTable(page.locator('#my-table'), {
-  headerSelector: 'thead th',
-  rowSelector: 'tbody tr',
-  cellSelector: 'td'
-});
-
-await table.init();
-
-// Get a row by content (current page)
+const table = await useTable(page.locator('#my-table')).init();
 const row = table.getRow({ Name: 'John Doe' });
 
-// Get a cell value
-const email = await row.getCell('Email').textContent();
+await expect(row.getCell('Email')).toHaveText('john@example.com');
 ```
 
 ## Type Safety
 
-The library is fully typed. When you initialize a table, TypeScript will infer the column names:
+Pass a row type to `useTable<T>()` when you want TypeScript to check filter keys and `toJSON()` output.
 
 ```typescript
-type MyTableRow = {
+type UserRow = {
   Name: string;
   Email: string;
   Status: string;
 };
 
-const table = useTable<MyTableRow>(page.locator('#table'), config);
+const table = useTable<UserRow>(page.locator('#table'));
+const user = await table.findRow({ Status: 'Active' });
+const data = await user.toJSON(); // UserRow
 ```

--- a/docs/api/smart-row-array.md
+++ b/docs/api/smart-row-array.md
@@ -1,4 +1,3 @@
-<!-- NEEDS REVIEW -->
 # SmartRowArray
 
 `SmartRowArray` is a specialized array of [SmartRow](/api/smart-row) objects returned by methods like [findRows()](/api/table-methods#findrows) and `table.filter()`.

--- a/docs/api/smart-row.md
+++ b/docs/api/smart-row.md
@@ -1,4 +1,3 @@
-<!-- NEEDS REVIEW -->
 # SmartRow
 
 A SmartRow is a Playwright Locator enhanced with column-aware methods. It extends the native Locator, so all Playwright methods work.
@@ -169,9 +168,9 @@ await row.getCell('Edit').click();
 
 #### Notes
 
-- Useful for tables with many rows
-- Ensures row is visible before interactions
-- Uses Playwright's `scrollIntoViewIfNeeded()`
+- Useful for rows returned by `findRow()`, `findRows()`, `filter()`, or `getRowByIndex()`
+- Navigates back to the row's page when pagination metadata is available
+- Ensures the row is visible before interactions
 
 ---
 
@@ -215,25 +214,49 @@ await row.smartFill({
   Department: 'Engineering'
 });
 
-// With custom options
+// With custom input mappers
 await row.smartFill(
   { Salary: '100000' },
-  { 
-    strategy: 'clickAndType',
-    clearFirst: true 
+  {
+    inputMappers: {
+      Salary: (cell) => cell.locator('input[name="salary"]')
+    }
   }
 );
 ```
 
 #### Fill Strategies
 
-The fill behavior is determined by the configured fill strategy:
+The default fill behavior detects common inputs automatically: text inputs, selects, checkboxes, radios, textareas, and `contenteditable` elements.
 
-- **ClickAndType** (default) - Click cell, clear, type
-- **DoubleClickAndType** - Double-click, clear, type
-- **Custom** - Define your own fill logic
+For app-specific widgets, use `columnOverrides.write` in `TableConfig`, or pass `inputMappers` for a one-off call.
 
 See [Fill Strategies](/api/strategies#fill) for more details.
+
+---
+
+### wasFound()
+
+Returns whether the row exists in the DOM. Rows returned from failed searches are sentinel rows, so they can still be used with Playwright negative assertions like `await expect(row).not.toBeVisible()`.
+
+<!-- api-signature: wasFound -->
+
+### Signature
+
+```typescript
+wasFound(): boolean
+```
+
+<!-- /api-signature: wasFound -->
+
+#### Example
+
+```typescript
+const row = table.getRow({ Name: 'Ghost User' });
+
+await expect(row).not.toBeVisible();
+expect(row.wasFound()).toBe(false);
+```
 
 ---
 

--- a/docs/api/strategies.md
+++ b/docs/api/strategies.md
@@ -12,6 +12,7 @@ Strategies define how the library interacts with different table implementations
 | **Fill** | `row.smartFill()` | Entering data into cells |
 | **Header** | `init()`, `revalidate()` | Finding and parsing column headers |
 | **Cell Locator** | `getCell()`, `toJSON()` | Custom cell resolution within a row |
+| **Viewport** | `getCell()`, `bringIntoView()` | Recovering rows/columns in 2D virtualized grids |
 
 ## Overview
 
@@ -228,14 +229,70 @@ When the DOM doesn't use predictable nth-child ordering (e.g. horizontally virtu
 
 ```typescript
 strategies: {
-  getCellLocator: ({ row, columnName, columnIndex }) => {
+  getCellLocator: ({ row, columnName, columnIndex, root, page, config }) => {
     // e.g. react-data-grid with aria-colindex attributes
     return row.locator(`[aria-colindex="${columnIndex}"]`);
   }
 }
 ```
 
-The function receives `{ row, columnName, columnIndex, rowIndex?, page }` and returns a `Locator`.
+The function receives `{ row, root, columnName, columnIndex, rowIndex?, page, config }` and returns a `Locator`.
+
+---
+
+## Viewport Strategy
+
+Viewport strategies help with 2D virtualized grids where rows and columns are both mounted only when visible. They let the cell-reading engine detect what is currently in the DOM and jump directly to the target row or column when scrolling one axis causes the other axis to unmount.
+
+### `Strategies.Viewport.dataAttribute(options?)`
+
+Use this when row and cell elements expose their indexes through DOM attributes.
+
+```typescript
+strategies: {
+  viewport: Strategies.Viewport.dataAttribute({
+    scrollContainer: '.grid-scroll-container',
+    rowAttribute: 'data-index',
+    columnAttribute: 'data-index'
+  })
+}
+```
+
+For ARIA grids, account for 1-based indexes:
+
+```typescript
+strategies: {
+  viewport: Strategies.Viewport.dataAttribute({
+    rowAttribute: 'aria-rowindex',
+    columnAttribute: 'aria-colindex',
+    rowOffset: 1,
+    columnOffset: 1
+  })
+}
+```
+
+### Custom Viewport Strategy
+
+Provide any combination of range oracles and scroll primitives:
+
+```typescript
+strategies: {
+  viewport: {
+    getVisibleRowRange: async ({ root }) => ({ first: 0, last: 20 }),
+    getVisibleColumnRange: async ({ root }) => ({ first: 0, last: 8 }),
+    scrollToRow: async ({ root }, rowIndex) => {
+      await root.evaluate((el, index) => {
+        el.querySelector(`[data-row-index="${index}"]`)?.scrollIntoView();
+      }, rowIndex);
+    },
+    scrollToColumn: async ({ root }, columnIndex) => {
+      await root.evaluate((el, index) => {
+        el.querySelector(`[data-column-index="${index}"]`)?.scrollIntoView();
+      }, columnIndex);
+    }
+  }
+}
+```
 
 ---
 

--- a/docs/api/table-config.md
+++ b/docs/api/table-config.md
@@ -55,7 +55,7 @@ headerSelector: (root) => root.locator('thead').locator('th')
 
 ### rowSelector
 
-**Type:** `string | ((root: Locator) => Locator)`  
+**Type:** `string`  
 **Required:** No  
 **Default:** `'tbody tr'`
 
@@ -113,7 +113,9 @@ Custom strategies for pagination, sorting, filling, etc. See [Strategies](/api/s
 strategies: {
   pagination: Strategies.Pagination.click({ next: '.next-button' }),
   sorting: Strategies.Sorting.AriaSort(),
-  fill: Strategies.Fill.ClickAndType()
+  fill: async ({ row, columnName, value }) => {
+    await row.getCell(columnName).locator('input').fill(String(value));
+  }
 }
 ```
 
@@ -121,17 +123,13 @@ strategies: {
 
 ### debug
 
-**Type:** `boolean | DebugConfig`  
+**Type:** `DebugConfig`  
 **Required:** No  
-**Default:** `false`
+**Default:** `undefined`
 
-Enable debug mode for slow motion, logging, and strict validation.
+Enable verbose logging or slow down table operations while troubleshooting.
 
 ```typescript
-// Simple
-debug: true
-
-// Advanced
 debug: {
   slow: 500,
   logLevel: 'verbose'
@@ -148,7 +146,7 @@ See the debug configuration options above for more details.
 **Required:** No  
 **Default:** `1`
 
-Maximum number of pages to traverse when using pagination methods like `findRows()`.
+Maximum number of pages to traverse when using pagination methods like `findRow()`, `findRows()`, `map()`, `forEach()`, and `filter()`. Keep the default for current-page scans; increase it when you want Smart Table to move through pagination.
 
 ```typescript
 maxPages: 10 // Stop after 10 pages
@@ -173,7 +171,7 @@ Default concurrency for `forEach`, `map`, and `filter`. Per-call options overrid
 
 **Type:** `boolean`  
 **Required:** No  
-**Default:** `false`
+**Default:** `true`
 
 When `true`, scrolls the table root into view during initialization.
 
@@ -184,7 +182,7 @@ When `true`, scrolls the table root into view during initialization.
 **Type:** `(context: TableContext) => Promise<void>`  
 **Required:** No
 
-Hook invoked when `table.reset()` runs, after pagination `goToFirst` (if configured) and before internal caches are cleared. Use for app-specific cleanup.
+Hook invoked when `table.reset()` runs, before pagination `goToFirst` (if configured) and before internal caches are cleared. Use for app-specific cleanup.
 
 ---
 
@@ -213,7 +211,9 @@ const table = useTable<Employee>(page.locator('#employees'), {
     sorting: Strategies.Sorting.AriaSort()
   },
   
-  debug: process.env.DEBUG === 'true',
+  debug: process.env.DEBUG === 'true'
+    ? { logLevel: 'verbose' }
+    : undefined,
   maxPages: 20
 });
 

--- a/docs/api/table-methods.md
+++ b/docs/api/table-methods.md
@@ -138,7 +138,7 @@ getRowByIndex(index: number): SmartRow
 
 ## findRow()
 
-Find the first row matching the filter, searching across multiple pages.
+Find the first row matching the filter. By default this scans one page (`maxPages: 1`); increase `maxPages` to search through pagination.
 
 
 <!-- api-signature: findRow -->
@@ -162,11 +162,11 @@ findRow(
 ### Example
 
 ```typescript
-// Find first row matching criteria (searches all pages)
+// Find first row matching criteria on the default scan range
 const row = await table.findRow({ Name: 'John Doe' });
 
-// Limit search to first 5 pages
-const row = await table.findRow(
+// Search up to the first 5 pages
+const rowWithinFivePages = await table.findRow(
   { Name: 'John Doe' },
   { maxPages: 5 }
 );
@@ -184,7 +184,7 @@ const exactRow = await table.findRow(
 
 ## findRows()
 
-Find all rows matching the filter across multiple pages.
+Find rows matching the filter. By default this scans one page (`maxPages: 1`); increase `maxPages` to collect rows across pagination.
 
 
 <!-- api-signature: findRows -->
@@ -216,11 +216,11 @@ const data = await rows.toJSON();
 ### Example
 
 ```typescript
-// Find all rows matching criteria (searches all pages)
+// Find rows matching criteria on the default scan range
 const rows = await table.findRows({ Status: 'Active' });
 
-// Limit search to first 10 pages
-const rows = await table.findRows(
+// Search up to the first 10 pages
+const rowsWithinTenPages = await table.findRows(
   { Status: 'Active' },
   { maxPages: 10 }
 );
@@ -239,7 +239,7 @@ const exactRows = await table.findRows(
 
 ## forEach()
 
-Iterate every row across all pages, calling the callback for side effects. Execution is sequential by default (safe for interactions like clicking/filling). Call `stop()` in the callback to end iteration early.
+Iterate rows in the configured scan range, calling the callback for side effects. Execution is sequential by default (safe for interactions like clicking/filling). Increase `maxPages` to iterate beyond the first page. Call `stop()` in the callback to end iteration early.
 
 <!-- api-signature: forEach -->
 
@@ -275,7 +275,7 @@ await table.forEach(async ({ row, rowIndex, stop }) => {
 
 ## map()
 
-Transform every row across all pages into a value. Returns a flat array. Execution is parallel within each page by default (safe for reads). Call `stop()` to halt after the current page finishes.
+Transform rows in the configured scan range into values. Returns a flat array. Execution is parallel within each page by default (safe for reads). Increase `maxPages` to map beyond the first page. Call `stop()` to halt after the current page finishes.
 
 > [!WARNING]
 > `map` defaults to `concurrency: 'parallel'`. If your callback opens popovers, fills inputs, or mutates UI state, pass `{ concurrency: 'sequential' }` or `{ concurrency: 'synchronized' }` as appropriate.
@@ -313,7 +313,7 @@ const assignees = await table.map(async ({ row }) => {
 
 ## filter()
 
-Filter rows across all pages by an async predicate. Returns a [SmartRowArray](/api/smart-row-array). Execution is sequential by default. Call `bringIntoView()` on each row if you need to interact after pagination.
+Filter rows in the configured scan range by an async predicate. Returns a [SmartRowArray](/api/smart-row-array). Execution is sequential by default. Increase `maxPages` to filter beyond the first page. Call `bringIntoView()` on each row if you need to interact after pagination.
 
 <!-- api-signature: filter -->
 
@@ -525,4 +525,18 @@ Generates an AI-friendly configuration prompt for debugging. Outputs table HTML 
 
 ```typescript
 generateConfig(): Promise<void>
+```
+
+[Back to Top](#table-methods)
+
+---
+
+## generateConfigPrompt()
+
+Deprecated alias for `generateConfig()`. Use `generateConfig()` in new code; `generateConfigPrompt()` will be removed in v7.0.0.
+
+### Signature
+
+```typescript
+generateConfigPrompt(): Promise<void>
 ```

--- a/docs/examples/ag-grid.md
+++ b/docs/examples/ag-grid.md
@@ -13,7 +13,7 @@ AG Grid is effectively tested by targeting its specific class names.
 ### Basic Setup
 
 ```typescript
-import { useTable, Strategies } from 'playwright-smart-table';
+import { useTable, Strategies } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(page.locator('.ag-root-wrapper'), {
   // AG Grid standard classes
@@ -90,7 +90,7 @@ graph TD
 ```typescript
 strategies: {
   pagination: Strategies.Pagination.infiniteScroll({
-    scrollContainer: page.locator('.ag-body-viewport'),
+    scrollTarget: '.ag-body-viewport',
   })
 }
 ```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,54 +1,48 @@
-<!-- NEEDS REVIEW -->
 # Examples
 
-Real-world examples of using Playwright Smart Table with different table libraries and patterns.
+Pick the example closest to what you are trying to do. If you are new, start with Basic Usage, then Pagination.
 
-## Quick Links
+## By Task
 
-- [Basic Usage](/examples/basic) - Simple table interactions
-- [Pagination](/examples/pagination) - Handling paginated tables
-- [Infinite Scroll](/examples/infinite-scroll) - Infinite scroll tables
-- [MUI DataGrid](/examples/mui-datagrid) - Material-UI DataGrid
-- [AG Grid](/examples/ag-grid) - AG Grid integration
+| I want to... | Start here |
+|---|---|
+| Find a row and assert a cell | [Basic Usage](/examples/basic) |
+| Search across pages | [Pagination](/examples/pagination) |
+| Work with infinite scroll | [Infinite Scroll](/examples/infinite-scroll) |
+| Extract many rows into data | [Data Scraping](/recipes/data-scraping) |
+| Use MUI DataGrid | [MUI DataGrid](/examples/mui-datagrid) |
+| Use AG Grid | [AG Grid](/examples/ag-grid) |
+| Write a custom strategy | [Custom Strategies](/recipes/custom-strategies) |
 
-## Common Patterns
+## Common Starting Points
 
-### Finding and Asserting
+### Assert a Cell by Column Name
 
 ```typescript
 const row = table.getRow({ Name: 'John Doe' });
 await expect(row.getCell('Email')).toHaveText('john@example.com');
 ```
 
-### Filtering and Iteration
+### Find Rows Across Pages
 
 ```typescript
 const engineers = await table.findRows({ Department: 'Engineering' });
-
-for (const engineer of engineers) {
-  const name = await engineer.getCell('Name').textContent();
-  console.log(name);
-}
+expect(engineers.length).toBeGreaterThan(0);
 ```
 
-### Data Export
+### Extract Data
 
 ```typescript
-const rows = await table.findRows({});
-const data = await rows.toJSON();
-console.log(JSON.stringify(data, null, 2));
+const data = await table.map(({ row }) => row.toJSON());
 ```
 
-### Editing Cells
+### Fill Editable Cells
 
 ```typescript
 const row = table.getRow({ ID: '12345' });
-await row.smartFill({
-  Email: 'new.email@example.com',
-  Phone: '555-1234'
-});
+await row.smartFill({ Email: 'new.email@example.com' });
 ```
 
-## Browse Examples
+## Need API Details?
 
-Click on the links above to see detailed examples for each use case.
+Use the [API Reference](/api/) when you know the method or config option and need exact signatures.

--- a/docs/examples/infinite-scroll.md
+++ b/docs/examples/infinite-scroll.md
@@ -8,7 +8,7 @@ Infinite scroll is common in modern feeds and dashboards. The library handles th
 Use the included `InfiniteScroll` strategy. It scrolls the container to the bottom and waits for new rows to appear.
 
 ```typescript
-import { useTable, Strategies } from 'playwright-smart-table';
+import { useTable, Strategies } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(page.locator('.feed-container'), {
   rowSelector: '.feed-item',
@@ -16,10 +16,10 @@ const table = useTable(page.locator('.feed-container'), {
   strategies: {
     pagination: Strategies.Pagination.infiniteScroll({
       // The element that has the overflow-y: scroll style
-      scrollContainer: page.locator('.feed-scroll-view'),
+      scrollTarget: '.feed-scroll-view',
       
-      // How long to wait for new items after scrolling (default: 1000ms)
-      waitForNewRows: 2000
+      // How long to wait for new items after scrolling
+      timeout: 2000
     })
   }
 });
@@ -44,16 +44,18 @@ Some implementations use a manual button instead of automatic scrolling. Use a c
 
 ```typescript
 strategies: {
-  pagination: async ({ page }) => {
-    const loadMore = page.locator('button:has-text("Load More")');
-    
-    if (await loadMore.isVisible()) {
-      await loadMore.click();
-      await page.waitForTimeout(500); // Wait for render
-      return true; // We "turned the page"
+  pagination: {
+    goNext: async ({ page }) => {
+      const loadMore = page.locator('button:has-text("Load More")');
+
+      if (await loadMore.isVisible() && await loadMore.isEnabled()) {
+        await loadMore.click();
+        await page.waitForTimeout(500); // Wait for render
+        return true; // We "turned the page"
+      }
+
+      return false; // Reached the end
     }
-    
-    return false; // Reached the end
   }
 }
 ```
@@ -69,6 +71,6 @@ const allItems = await table.map(async ({ row }) => {
 }, {
   // dedupe is important for infinite scroll!
   // Rows often stay in the DOM, so we might see them again.
-  dedupeStrategy: (row) => row.getCell('ID').innerText()
+  dedupe: (row) => row.getCell('ID').innerText()
 });
 ```

--- a/docs/examples/mui-datagrid.md
+++ b/docs/examples/mui-datagrid.md
@@ -13,26 +13,11 @@ MUI DataGrid uses specific roles and classes. You'll need to configure selectors
 ### Basic Setup
 
 ```typescript
-import { useTable, Strategies } from 'playwright-smart-table';
+import { useTable, presets } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(page.locator('.MuiDataGrid-root'), {
-  // MUI uses ARIA roles efficiently
-  rowSelector: 'div[role="row"]',
-  cellSelector: 'div[role="gridcell"]',
-  headerSelector: 'div[role="columnheader"]',
-  
-  // Header text often includes sort icons/menus, so we clean it up
-  headerTransformer: ({ text }) => text.trim(),
-  
-  strategies: {
-    // MUI uses standard ARIA sort attributes
-    sorting: Strategies.Sorting.AriaSort(),
-    
-    // Pagination (if using paginated view)
-    pagination: Strategies.Pagination.click({ next: 
-      'button[title="Go to next page"]'
-    })
-  }
+  ...presets.muiDataGrid,
+  maxPages: 5
 });
 
 await table.init();
@@ -42,33 +27,35 @@ await table.init();
 
 MUI DataGrid is virtualized, meaning only visible rows exist in the DOM.
 
-### Scrolling
+### Viewport Recovery
 
-The library's `findRow` naturally handles searching across pages, but for virtual scrolling (infinite scroll style), you should use the `InfiniteScroll` pagination strategy.
+The MUI DataGrid preset includes a viewport strategy that reports visible row/column ranges and scrolls directly to target rows or columns. This lets `row.getCell()` recover when horizontal column scrolling knocks the target row out of the DOM.
 
 ```typescript
-strategies: {
-  pagination: Strategies.Pagination.infiniteScroll({
-    scrollContainer: page.locator('.MuiDataGrid-virtualScroller'),
-    waitForNewRows: 500 // Wait for virtualization to render
-  })
-}
+const row = await table.findRow({ 'Last name': 'Lannister' });
+await expect(row.getCell('First name')).toHaveText('Cersei');
 ```
 
 ## Cell Editing
 
-MUI DataGrid often requires a double-click to edit.
+For custom editors, use `columnOverrides.write` to describe exactly how to open and commit the widget.
 
 ```typescript
-strategies: {
-  fill: Strategies.Fill.DoubleClickAndType({
-    clearFirst: true,
-    pressEnter: true
-  })
-}
+const table = useTable(page.locator('.MuiDataGrid-root'), {
+  ...presets.muiDataGrid,
+  columnOverrides: {
+    'First name': {
+      write: async ({ cell, targetValue }) => {
+        await cell.dblclick();
+        await cell.locator('input').fill(String(targetValue));
+        await cell.page().keyboard.press('Enter');
+      }
+    }
+  }
+});
 
 // Usage
-await row.smartFill({ 'First Name': 'Jane' });
+await row.smartFill({ 'First name': 'Jane' });
 ```
 
 ## Complete Test Example
@@ -78,9 +65,8 @@ test('MUI DataGrid interaction', async ({ page }) => {
   await page.goto('https://mui.com/x/react-data-grid/');
   
   const table = useTable(page.locator('.MuiDataGrid-root').first(), {
-    rowSelector: 'div[role="row"]',
-    cellSelector: 'div[role="gridcell"]',
-    headerSelector: 'div[role="columnheader"]',
+    ...presets.muiDataGrid,
+    maxPages: 5
   });
   
   // Find a row

--- a/docs/examples/pagination.md
+++ b/docs/examples/pagination.md
@@ -1,5 +1,8 @@
-<!-- NEEDS REVIEW -->
-# Pagination Examples of handling paginated tables.
+# Pagination Examples
+
+Use pagination strategies when Smart Table needs to move through pages while searching or iterating.
+
+By default, Smart Table only scans one page (`maxPages: 1`). To search or iterate beyond the current page, configure `maxPages` on the table or pass it to the method call.
 
 ## Basic Pagination
 
@@ -8,8 +11,11 @@ import { useTable, Strategies } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(page.locator('#table'), {
   strategies: {
-    pagination: Strategies.Pagination.click({ next: '.pagination .next' })
-  }
+    pagination: Strategies.Pagination.click({
+      next: () => page.locator('.pagination .next')
+    })
+  },
+  maxPages: 5
 });
 
 await table.init();
@@ -18,11 +24,11 @@ await table.init();
 ## Finding Across Pages
 
 ```typescript
-// Automatically searches all pages
+// Uses the table-level maxPages value
 const row = await table.findRow({ Name: 'Cedric Kelly' });
 
-// Limit search to 5 pages
-const row = await table.findRow(
+// Or override the page limit for one search
+const rowWithinFivePages = await table.findRow(
   { Department: 'Engineering' },
   { maxPages: 5 }
 );
@@ -31,37 +37,38 @@ const row = await table.findRow(
 ## Getting All Matching Rows
 
 ```typescript
-// Find all engineers across all pages
 const engineers = await table.findRows({
   Department: 'Engineering'
 });
 
 console.log(`Found ${engineers.length} engineers`);
 
-// Limit pages
-const engineers = await table.findRows(
+const engineersWithinTenPages = await table.findRows(
   { Department: 'Engineering' },
   { maxPages: 10 }
 );
 ```
 
-## Iterating Through All Pages
+## Iterating Through Multiple Pages
 
 ```typescript
-await table.forEach(async ({ row, rowIndex }) => {
-  const name = await row.getCell('Name').textContent();
-  console.log(`${rowIndex}: ${name}`);
-});
+await table.forEach(
+  async ({ row, rowIndex }) => {
+    const name = await row.getCell('Name').textContent();
+    console.log(`${rowIndex}: ${name}`);
+  },
+  { maxPages: 5 }
+);
 ```
 
 ## Scanning Column Values
 
 ```typescript
-// Get all email addresses across all pages
+// Get email addresses from the default scan range
 const emails = await table.map(({ row }) => row.getCell('Email').innerText());
 
-// With page limit
-const emails = await table.map(({ row }) => row.getCell('Email').innerText(), {
+// Or override the page limit for one scan
+const limitedEmails = await table.map(({ row }) => row.getCell('Email').innerText(), {
   maxPages: 5
 });
 ```
@@ -72,7 +79,7 @@ const emails = await table.map(({ row }) => row.getCell('Email').innerText(), {
 const table = useTable(page.locator('#table'), {
   strategies: {
     pagination: {
-      goNext: async ({ page, rootLocator }) => {
+      goNext: async ({ page }) => {
         const nextBtn = page.locator('.custom-next-button');
         
         // Check if there are more pages
@@ -97,10 +104,20 @@ const table = useTable(page.locator('#table'), {
 ```typescript
 const table = useTable(page.locator('#table'), {
   strategies: {
-    pagination: Strategies.Pagination.ClickPageNumber({
-      pageNumberSelector: (pageNum) => 
-        page.locator(`.pagination button:has-text("${pageNum}")`)
-    })
+    pagination: {
+      goNext: async ({ page }) => {
+        const next = page.getByRole('button', { name: 'Next' });
+        if (await next.isDisabled()) return false;
+        await next.click();
+        return true;
+      },
+      goToPage: async (pageIndex, { page }) => {
+        const button = page.getByRole('button', { name: String(pageIndex + 1) });
+        if (await button.count() === 0) return false;
+        await button.click();
+        return true;
+      }
+    }
   }
 });
 ```
@@ -117,18 +134,20 @@ test('paginated table search', async ({ page }) => {
   const table = useTable(page.locator('#example'), {
     headerSelector: 'thead th',
     strategies: {
-      pagination: Strategies.Pagination.click({ next: '#example_next' })
+      pagination: Strategies.Pagination.click({
+        next: () => page.locator('#example_next')
+      })
     },
     maxPages: 10
   });
   
   await table.init();
   
-  // Find row that might be on any page
+  // Find a row within the configured page limit
   const row = await table.findRow({ Name: 'Cedric Kelly' });
   await expect(row.getCell('Position')).toHaveText('Senior JavaScript Developer');
   
-  // Get all San Francisco employees (across all pages)
+  // Get San Francisco employees within the configured page limit
   const sfEmployees = await table.findRows({
     Office: 'San Francisco'
   });

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -37,10 +37,9 @@ const table = useTable(page.locator('.grid-container'), {
 ```
 
 > [!TIP]
-> You can pass functions if you need complex logic like filtering:
+> You can pass functions for `headerSelector` and `cellSelector` when you need complex locator logic:
 > ```typescript
-> // Only select rows that contain actual data cells (excluding headers/separators)
-> rowSelector: (root) => root.locator('div.row').filter({ has: root.locator('.cell') })
+> cellSelector: (row) => row.locator('div.cell').filter({ hasNotText: 'Loading...' })
 > ```
 
 ## Header Transformation
@@ -68,7 +67,8 @@ const table = useTable(loc, {
 });
 
 // Now you can use the clean name:
-table.getCell('First Name');
+const row = table.getRow({ 'First Name': 'Ada' });
+row.getCell('First Name');
 ```
 
 ## Strategies
@@ -76,7 +76,7 @@ table.getCell('First Name');
 Configuration is also where you attach behavior strategies.
 
 ```typescript
-import { Strategies } from 'playwright-smart-table';
+import { Strategies } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(loc, {
   strategies: {

--- a/docs/guide/core-concepts.md
+++ b/docs/guide/core-concepts.md
@@ -1,66 +1,80 @@
 <!-- Last Reviewed: 02/06/2026 -->
 # Core Concepts
 
-Understanding the key concepts of Playwright Smart Table.
+There are three ideas to understand: a table helper, smart rows, and strategies.
 
-## SmartRow
+## 1. The Table Helper
 
-A SmartRow is a Playwright Locator enhanced with column-aware methods.
+`useTable(root)` creates a helper around one table-like element. It reads headers, caches the column map, and uses that map whenever you ask for a row or cell.
 
 ```typescript
-const row = await table.findRow({ Name: 'John Doe' });
+const table = await useTable(page.locator('#employees')).init();
+const headers = await table.getHeaders();
+```
+
+Call `reset()` when your app returns the table to its starting state. Call `revalidate()` when the visible columns changed and you want to refresh the header map without resetting pagination.
+
+## 2. SmartRow
+
+A `SmartRow` is a Playwright `Locator` with table-aware methods added.
+
+```typescript
+const row = table.getRow({ Name: 'Airi Satou' });
 
 // Column-aware access
-const email = row.getCell('Email');
+await expect(row.getCell('Office')).toHaveText('Tokyo');
 
-// Still a Locator - all Playwright methods work
+// It is still a Locator
 await expect(row).toBeVisible();
 await row.click();
 ```
 
-Learn more: [SmartRow API](/api/smart-row)
+Use `row.toJSON()` to read row data, `row.smartFill()` to fill editable cells, and `row.bringIntoView()` before interacting with a row returned from a paginated scan.
 
-## Strategies
+Learn more in the [SmartRow API](/api/smart-row).
 
-Strategies define how the library interacts with different table implementations. Use built-in strategies or provide your own.
+## 3. Strategies
+
+Strategies tell Smart Table how your table behaves when normal HTML-table assumptions are not enough.
 
 ```typescript
 import { Strategies, useTable } from '@rickcedwhat/playwright-smart-table';
 
-// Built-in strategies
 const table = useTable(page.locator('#table'), {
   strategies: {
     pagination: Strategies.Pagination.click({ next: '.next-btn' }),
-    sorting: Strategies.Sorting.AriaSort(),
-    // Custom fill: click cell, then type (e.g. for inline editors)
-    fill: async ({ row, columnName, value, page }) => {
-      const cell = row.getCell(columnName);
-      await cell.click();
-      await page.keyboard.type(String(value));
-    }
+    sorting: Strategies.Sorting.AriaSort()
   }
 });
 ```
 
-Learn more: [Strategies API](/api/strategies)
+Common strategies:
+
+| Strategy | Use it when... |
+|---|---|
+| `pagination` | Smart Table needs to move to the next page or scroll batch. |
+| `sorting` | You want `table.sorting.apply()` and `table.sorting.getState()`. |
+| `viewport` | Rows and columns are virtualized and may unmount while scrolling. |
+| `getCellLocator` | Cells cannot be resolved by simple column index. |
+| `fill` / `columnOverrides.write` | Editable cells need app-specific interaction logic. |
+
+Learn more in the [Strategies API](/api/strategies).
 
 ## Auto-Initialization
 
-Most methods auto-initialize the table:
+Async search and iteration methods initialize automatically. Current-page sync methods need `init()` first.
 
 ```typescript
-// No need to call init() for async methods
-const row = await table.findRow({ Name: 'John' }); // Auto-initializes
-const rows = await table.findRows({}, { maxPages: 1 }); // Auto-initializes
+const asyncTable = useTable(page.locator('#table'));
+const row = await asyncTable.findRow({ Name: 'John' }); // auto-initializes
 
-// Only needed for sync methods
-await table.init();
-const row = table.getRowByIndex(0); // Requires init()
+const table = await useTable(page.locator('#table')).init();
+const firstRow = table.getRowByIndex(0); // current-page sync access
 ```
 
 ## Type Safety
 
-Define your table structure for full TypeScript support:
+Define your row shape when you want TypeScript to check column names and JSON output.
 
 ```typescript
 type Employee = {
@@ -72,25 +86,14 @@ type Employee = {
 
 const table = useTable<Employee>(page.locator('#table'));
 
-// TypeScript knows the columns
 const row = await table.findRow({ 
   Name: 'John',
-  InvalidColumn: 'x' // ❌ TypeScript error
+  InvalidColumn: 'x' // TypeScript error
 });
 ```
 
-## Parallel Execution
-
-Playwright Smart Table is fully compatible with Playwright's parallel execution.
-
-- **Stateless**: `SmartRow` and `TableResult` objects are stateless wrappers around Playwright Locators.
-- **Safe**: No global state is shared between tests or workers.
-- **Independent**: Each `useTable` call creates a fresh instance scoped to the specific `page` object.
-
-You can safely run tests in parallel using `fullyParallel: true` in your Playwright config.
-
 ## Next Steps
 
-- [Configuration](/guide/configuration) - Customize table behavior
-- [API Reference](/api/) - Complete method documentation
-- [Examples](/examples/) - Real-world usage patterns
+- [Configuration](/guide/configuration): customize selectors and behavior.
+- [Examples](/examples/): choose a task-based example.
+- [API Reference](/api/): look up exact method details.

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -1,8 +1,51 @@
 # Debugging
 
-🚧 **Under Construction**
+When Smart Table cannot find a row or column, start by checking what it sees: headers, selectors, and pagination state.
 
-This page is being built. Check back soon!
+## Turn On Logs
 
-For now, see:
-- [TableConfig API](/api/table-config#debug) - Debug configuration options
+```typescript
+const table = useTable(page.locator('#table'), {
+  debug: {
+    logLevel: 'verbose',
+    slow: 250
+  }
+});
+```
+
+`logLevel: 'verbose'` prints table mapping, row search, pagination, and cell resolution decisions. `slow` adds small delays so you can watch the browser while a test runs.
+
+## Check Detected Headers
+
+Most “column not found” problems come from header text that does not match what the test expects.
+
+```typescript
+const table = await useTable(page.locator('#table')).init();
+console.log(await table.getHeaders());
+```
+
+If headers include extra text like sort icons or counts, normalize them with `headerTransformer`.
+
+```typescript
+const table = useTable(page.locator('#table'), {
+  headerTransformer: ({ text }) => text.replace(/Sort$/, '').trim()
+});
+```
+
+## Verify Selectors
+
+If `getHeaders()` returns an empty list, the table root or selectors are wrong. Start with the smallest config that matches your DOM:
+
+```typescript
+const table = useTable(page.locator('.grid-root'), {
+  headerSelector: '[role="columnheader"]',
+  rowSelector: '[role="row"]',
+  cellSelector: '[role="gridcell"]'
+});
+```
+
+## More Help
+
+- [Troubleshooting](/troubleshooting): common errors and fixes.
+- [TableConfig debug option](/api/table-config#debug): exact debug config shape.
+- [Advanced Debugging](/advanced/debugging): lower-level diagnostics.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,19 +1,15 @@
 <!-- Last Reviewed: 02/06/2026 -->
 # Getting Started
 
-Learn how to install and use Playwright Smart Table in your tests.
+This guide gets you from install to a useful table test. Start here if you are new to the library.
 
 ## Installation
 
 ```bash
 npm install @rickcedwhat/playwright-smart-table
-# or
-yarn add @rickcedwhat/playwright-smart-table
-# or
-pnpm add @rickcedwhat/playwright-smart-table
 ```
 
-## Quick Start
+## Your First Test
 
 ```typescript
 import { test, expect } from '@playwright/test';
@@ -21,15 +17,10 @@ import { useTable } from '@rickcedwhat/playwright-smart-table';
 
 test('find and verify employee', async ({ page }) => {
   await page.goto('https://datatables.net/examples/data_sources/dom');
-  
-  // Initialize table
-  const table = useTable(page.locator('#example'));
-  await table.init();
 
-  // Get a row by content (current page)
+  const table = await useTable(page.locator('#example')).init();
   const row = table.getRow({ Name: 'Airi Satou' });
-  
-  // Verify cell values (returns Locator)
+
   await expect(row.getCell('Position')).toHaveText('Accountant');
   await expect(row.getCell('Office')).toHaveText('Tokyo');
 });
@@ -37,28 +28,85 @@ test('find and verify employee', async ({ page }) => {
 
 ## Why This Works
 
-Notice how we:
-- **Get rows by content** (`Name: 'Airi Satou'`) instead of fragile XPath
-- **Access cells by column name** (`getCell('Position')`) instead of index
-- **No manual column mapping** - the library reads headers automatically
+`useTable()` reads the table headers and remembers which column index belongs to each name. `getRow()` finds a row by cell text, and `getCell()` returns a normal Playwright `Locator`, so Playwright assertions and actions still work.
 
-> [!TIP]
-> Use `getRow()` for fast lookups on the current page. Use `findRow()` when you need to search across multiple paginated pages.
+That means your test can say “the row where `Name` is `Airi Satou`, then the `Office` cell” instead of relying on `nth()` indexes.
 
-## Configuration
+## Which Method Should I Use?
 
-Customize selectors for your table structure:
+| If you need to... | Use this |
+|---|---|
+| Find a row on the current page | `table.getRow(filters)` |
+| Search through paginated data for one row | `await table.findRow(filters, { maxPages })` |
+| Collect matching rows across pages | `await table.findRows(filters, { maxPages })` |
+| Read a value from every row | `await table.map(({ row }) => ...)` |
+| Click, fill, or assert every row in order | `await table.forEach(async ({ row }) => ...)` |
+
+### Current Page
+
+Use `getRow()` when the row is already visible. Because it is synchronous, call `init()` first.
 
 ```typescript
-const table = useTable(page.locator('#table'), {
-  headerSelector: 'thead th',  // Optional, defaults to 'thead th'
-  rowSelector: 'tbody tr',     // Optional, defaults to 'tbody tr'
-  cellSelector: 'td'           // Optional, defaults to 'td'
+const table = await useTable(page.locator('#example')).init();
+
+const row = table.getRow({ Name: 'Airi Satou' });
+await expect(row.getCell('Office')).toHaveText('Tokyo');
+```
+
+### Paginated Tables
+
+Use `findRow()` or `findRows()` when the table may need to move through pages. Add a pagination strategy so Smart Table knows how to click Next, and increase `maxPages` above the default of `1`.
+
+```typescript
+import { Strategies, useTable } from '@rickcedwhat/playwright-smart-table';
+
+const table = useTable(page.locator('#example'), {
+  strategies: {
+    pagination: Strategies.Pagination.click({
+      next: () => page.getByRole('link', { name: 'Next' })
+    })
+  },
+  maxPages: 5
+});
+
+const row = await table.findRow({ Name: 'Colleen Hurst' });
+await expect(row.getCell('Office')).toHaveText('San Francisco');
+```
+
+### Reading Every Row
+
+Use `map()` for data extraction. It returns a plain array.
+
+```typescript
+const offices = await table.map(({ row }) => row.getCell('Office').innerText());
+expect(offices).toContain('Tokyo');
+```
+
+Use `forEach()` for ordered interactions.
+
+```typescript
+await table.forEach(async ({ row }) => {
+  await expect(row.getCell('Status')).toHaveText('Active');
 });
 ```
 
+## When Defaults Do Not Work
+
+Standard HTML tables often work with no selector config. For `div`-based grids, tell Smart Table where headers, rows, and cells live.
+
+```typescript
+const table = useTable(page.locator('#table'), {
+  headerSelector: '[role="columnheader"]',
+  rowSelector: '[role="row"]',
+  cellSelector: '[role="gridcell"]'
+});
+```
+
+If your table needs special behavior, use a strategy. Common examples are pagination, sorting, virtualized columns, and custom filling.
+
 ## Next Steps
 
-- [Core Concepts](/guide/core-concepts) - Understand SmartRow and strategies
-- [API Reference](/api/) - Complete method documentation
-- [Examples](/examples/) - Real-world usage patterns
+- [Core Concepts](/guide/core-concepts): learn the three main ideas.
+- [Examples](/examples/): pick a task-based example.
+- [Configuration](/guide/configuration): adapt Smart Table to a custom DOM.
+- [API Reference](/api/): look up exact method and config details.

--- a/docs/guide/recipes.md
+++ b/docs/guide/recipes.md
@@ -1,10 +1,14 @@
-<!-- NEEDS REVIEW -->
 # Recipes
 
-🚧 **Under Construction**
+Recipes are task-focused guides for common table-testing patterns. They are separate from the API reference because they start with what you are trying to accomplish.
 
-This page is being built. Check back soon!
+## Available Recipes
 
-For now, see:
-- [Examples](/examples/) - Real-world usage patterns
-- [API Reference](/api/) - Complete method documentation
+- [Data Scraping](/recipes/data-scraping): extract rows, columns, JSON, or CSV-style output.
+- [Custom Strategies](/recipes/custom-strategies): adapt Smart Table to custom pagination, filling, or cell lookup behavior.
+- [Performance Tips](/recipes/performance): keep large-table tests fast and reliable.
+
+## Related Pages
+
+- [Examples](/examples/): short examples by table type or workflow.
+- [Troubleshooting](/troubleshooting): fixes for common setup and runtime issues.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,132 +1,53 @@
-# Introduction
+# Playwright Smart Table
 
-## Why Playwright Smart Table?
+Playwright Smart Table helps you test tables by column name instead of DOM position. It maps the headers once, returns normal Playwright Locators, and adds table-aware helpers for rows and cells.
 
-Testing HTML tables in Playwright is painful. Traditional approaches are fragile and hard to maintain.
-
-### The Problem
-
-**Traditional approach:**
+## 30-Second Example
 
 ```typescript
-// ❌ Fragile - breaks if columns reorder
-const email = await page.locator('tbody tr').nth(2).locator('td').nth(3).textContent();
+import { test, expect } from '@playwright/test';
+import { useTable } from '@rickcedwhat/playwright-smart-table';
 
-// ❌ Brittle XPath
-const row = page.locator('//tr[td[contains(text(), "John")]]');
+test('verify an employee row', async ({ page }) => {
+  await page.goto('https://datatables.net/examples/data_sources/dom');
 
-// ❌ Manual column mapping
-const headers = await page.locator('thead th').allTextContents();
-const emailIndex = headers.indexOf('Email');
-const email = await row.locator('td').nth(emailIndex).textContent();
-```
+  const table = await useTable(page.locator('#example')).init();
+  const row = table.getRow({ Name: 'Airi Satou' });
 
-**Problems:**
-- Column indices break when columns reorder
-- XPath is hard to read and maintain
-- Manual header mapping is tedious
-- No type safety
-- Pagination requires custom logic
-
-### The Solution
-
-**Playwright Smart Table:**
-
-```typescript
-// ✅ Column-aware - survives column reordering
-const row = table.getRow({ Name: 'John Doe' });
-const email = await row.getCell('Email').textContent();
-
-// ✅ Auto-pagination across all pages
-const allEngineers = await table.findRows({ Department: 'Engineering' });
-
-// ✅ Type-safe
-type Employee = { Name: string; Email: string; Department: string };
-const table = useTable<Employee>(page.locator('#table'));
-```
-
-## Key Features
-
-### 🎯 Smart Locators
-
-Find rows by content, not position:
-
-```typescript
-const row = table.getRow({ Name: 'Airi Satou', Office: 'Tokyo' });
-```
-
-### 📄 Auto-Pagination
-
-Search across all pages automatically:
-
-```typescript
-const row = await table.findRow({ ID: '12345' }); // Searches across ALL pages
-```
-
-### 🔍 Column-Aware Access
-
-Access cells by column name:
-
-```typescript
-const email = row.getCell('Email'); // No manual mapping needed
-```
-
-### 🛠️ Debug Mode
-
-Visual debugging with slow motion and logging:
-
-```typescript
-const table = useTable(page.locator('#table'), {
-  debug: { slow: 500, logLevel: 'verbose' }
+  await expect(row.getCell('Position')).toHaveText('Accountant');
+  await expect(row.getCell('Office')).toHaveText('Tokyo');
 });
 ```
 
-### 🔌 Extensible Strategies
+The important part is the mental model:
 
-Support any table implementation:
+- `useTable(root)` creates a table helper scoped to one table.
+- `table.init()` reads the headers and builds the column map.
+- `table.getRow({ Name: 'Airi Satou' })` finds a row by cell text.
+- `row.getCell('Office')` returns a regular Playwright `Locator`.
 
-```typescript
-import { Strategies } from '@rickcedwhat/playwright-smart-table';
+## Most Users Need Four Methods
 
-const table = useTable(page.locator('#table'), {
-  strategies: {
-    pagination: Strategies.Pagination.click({ next: '.next-btn' }),
-    sorting: Strategies.Sorting.AriaSort()
-  }
-});
-```
+| Need | Use |
+|---|---|
+| Get a row already visible on the current page | `table.getRow(filters)` |
+| Search more than the current page | `await table.findRow(filters, { maxPages: 5 })` |
+| Collect matching rows across pages | `await table.findRows(filters, { maxPages: 5 })` |
+| Read or validate every row | `await table.map(...)` or `await table.forEach(...)` |
 
-## When to Use This Library
+## When It Helps
 
-**Use this library when you need to:**
+Use this library when your tests need to:
 
-- ✅ **Find rows by column values** - "Get the row where Name is 'John' and Status is 'Active'"
-- ✅ **Access cells by column name** - "Get the Email cell from this row"
-- ✅ **Search across paginated tables** - "Find all rows with Department 'Engineering' across all pages"
-- ✅ **Handle column reordering** - Your tests survive when columns move
-- ✅ **Extract structured data** - Convert table rows to JSON objects
-- ✅ **Fill/edit table cells** - Smart filling with custom strategies
-- ✅ **Work with dynamic tables** - MUI DataGrid, AG Grid, custom implementations
+- Find rows by meaningful cell values, not `nth()` indexes.
+- Read, assert, or click cells by column name.
+- Search across paginated or infinitely scrolling tables by configuring pagination and increasing `maxPages`.
+- Extract row data with `toJSON()`.
+- Adapt to grids like MUI DataGrid, AG Grid, React Data Grid, or custom table-like DOM.
 
-**You might not need this library if:**
+## Where To Go Next
 
-- ❌ You don't deal with tables
-- ❌ You don't need to handle pagination or virtualization
-- ❌ You enjoy writing complex CSS selectors manually
-- ❌ You like doing things the hard way
-
-## Quick Comparison
-
-| Task | Traditional | Smart Table |
-|------|------------|-------------|
-| Find row | `page.locator('//tr[td[contains(text(), "John")]]')` | `table.getRow({ Name: 'John' })` |
-| Get cell | `row.locator('td').nth(3)` | `row.getCell('Email')` |
-| Pagination | Manual loop + click logic | `table.findRows({ ... })` |
-| Type safety | None | Full TypeScript support |
-| Column reorder | Breaks | Survives |
-
-## Get Started
-
-Ready to simplify your table tests?
-
-[Get Started →](/guide/getting-started)
+- [Getting Started](/guide/getting-started): install the package and write the first test.
+- [Core Concepts](/guide/core-concepts): understand `TableResult`, `SmartRow`, and strategies.
+- [Examples](/examples/): choose a task-based example.
+- [API Reference](/api/): look up exact method and config details.

--- a/docs/recipes/custom-strategies.md
+++ b/docs/recipes/custom-strategies.md
@@ -11,12 +11,12 @@ A Strategy is simply a function that implements specific behavior. You can overr
 Handle complex pagination logic like "Load More" buttons or infinite scroll triggers.
 
 ```typescript
-import { useTable, Strategies } from 'playwright-smart-table';
+import { useTable, Strategies } from '@rickcedwhat/playwright-smart-table';
 
 const table = useTable(page.locator('table'), {
   strategies: {
     pagination: {
-      goNext: async ({ page, rootLocator }) => {
+      goNext: async ({ page, root }) => {
           // 1. Detect if there's a next page
           const loadMore = page.locator('button:has-text("Load More")');
           

--- a/docs/recipes/data-scraping.md
+++ b/docs/recipes/data-scraping.md
@@ -4,7 +4,7 @@ Learn how to efficiently extract data from tables, whether they are small, pagin
 
 ## Extracting All Data
 
-The most efficient way to scrape an entire table is using `table.map()`. This handles pagination automatically and processes rows in chunks.
+The most efficient way to scrape a table is using `table.map()`. It processes rows in chunks and follows pagination up to the configured `maxPages` limit.
 
 ```typescript
 // Define the data shape you want to extract
@@ -50,11 +50,13 @@ stream.end();
 
 ## Scraping Specific Columns
 
-If you only need values from a single column across all pages, use `table.map()`.
+If you only need values from a single column, use `table.map()`. Increase `maxPages` when you want to scan beyond the first page.
 
 ```typescript
-// Get all email addresses from the entire table
-const emails = await table.map(({ row }) => row.getCell('Email').innerText());
+const emails = await table.map(
+  ({ row }) => row.getCell('Email').innerText(),
+  { maxPages: 5 }
+);
 
 // Get and transform values (e.g., parse currency)
 const salaries = await table.map(async ({ row }) => {

--- a/docs/recipes/performance.md
+++ b/docs/recipes/performance.md
@@ -37,10 +37,10 @@ const data = await row.toJSON({
 If you know the row is on the first page, use `getRow()` (sync-like) instead of `findRow()` (async search).
 
 ```typescript
-// ❌ Searches all pages (overhead)
+// Slower: async search path, and may scan multiple pages when maxPages is raised
 await table.findRow({ ID: '123' });
 
-// ✅ Checks current page immediately
+// Faster: checks the current page immediately
 table.getRow({ ID: '123' }); 
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,7 +97,8 @@ import { Strategies } from '@rickcedwhat/playwright-smart-table';
 const table = useTable(page.locator('#table'), {
   strategies: {
     pagination: Strategies.Pagination.click({ next: '.next-button' })
-  }
+  },
+  maxPages: 10
 });
 ```
 
@@ -113,7 +114,7 @@ await page.locator('.next-button').click(); // Should navigate
 ```typescript
 const rows = await table.findRows(
   { Office: 'Tokyo' },
-  { maxPages: 10 } // Limit search
+  { maxPages: 10 } // Default is 1; raise it to scan more pages
 );
 ```
 

--- a/scripts/embed-config-types.mjs
+++ b/scripts/embed-config-types.mjs
@@ -18,7 +18,7 @@ try {
  * rowSelector: 'tbody tr'
  * 
  * // Function selector
- * rowSelector: (root) => root.locator('[role="row"]')
+ * headerSelector: (root) => root.locator('[role="columnheader"]')
  */
 export type Selector = string | ((root: Locator | Page) => Locator);
 

--- a/src/minimalConfigContext.ts
+++ b/src/minimalConfigContext.ts
@@ -11,7 +11,7 @@ export const MINIMAL_CONFIG_CONTEXT = `
  * rowSelector: 'tbody tr'
  * 
  * // Function selector
- * rowSelector: (root) => root.locator('[role="row"]')
+ * headerSelector: (root) => root.locator('[role="columnheader"]')
  */
 export type Selector = string | ((root: Locator | Page) => Locator);
 

--- a/src/typeContext.ts
+++ b/src/typeContext.ts
@@ -11,7 +11,7 @@ export const TYPE_CONTEXT = `
  * rowSelector: 'tbody tr'
  * 
  * // Function selector
- * rowSelector: (root) => root.locator('[role="row"]')
+ * headerSelector: (root) => root.locator('[role="columnheader"]')
  */
 export type Selector = string | ((root: Locator | Page) => Locator) | ((root: Locator) => Locator);
 
@@ -211,8 +211,9 @@ export type SmartRow<T = any> = Locator & {
 
   /**
    * Scrolls/paginates to bring this row into view.
-   * Only works if rowIndex is known (e.g., from getRowByIndex).
-   * @throws Error if rowIndex is unknown
+   * Works when row position metadata is known (e.g., from getRowByIndex, findRow,
+   * findRows, filter, or async iteration).
+   * @throws Error if row position metadata is unknown
    */
   bringIntoView(): Promise<void>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import type { SmartRowArray } from './utils/smartRowArray';
  * rowSelector: 'tbody tr'
  * 
  * // Function selector
- * rowSelector: (root) => root.locator('[role="row"]')
+ * headerSelector: (root) => root.locator('[role="columnheader"]')
  */
 export type Selector = string | ((root: Locator | Page) => Locator) | ((root: Locator) => Locator);
 
@@ -208,8 +208,9 @@ export type SmartRow<T = any> = Locator & {
 
   /**
    * Scrolls/paginates to bring this row into view.
-   * Only works if rowIndex is known (e.g., from getRowByIndex).
-   * @throws Error if rowIndex is unknown
+   * Works when row position metadata is known (e.g., from getRowByIndex, findRow,
+   * findRows, filter, or async iteration).
+   * @throws Error if row position metadata is unknown
    */
   bringIntoView(): Promise<void>;
 


### PR DESCRIPTION
## Summary
- Reshape the docs landing, getting started, core concepts, examples, and API entry pages around a clearer new-user path.
- Replace placeholder docs and stale pagination examples with current guidance.
- Clarify that `maxPages` defaults to `1` and must be raised to scan beyond the current page.

## Test plan
- `npm run docs:build`
- `npm run docs:verify-links`
- Pre-commit build/docs generation completed successfully during commit.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wasFound()` method to detect failed searches with sentinel rows
  * Added Viewport strategy for 2D virtualized grid support

* **Documentation**
  * Clarified pagination defaults: search methods now scan a single page by default (configurable via `maxPages`)
  * Updated examples and API guidance for improved clarity on pagination, fill strategies, and configuration options

* **Chores**
  * Deprecated `generateConfigPrompt()` alias; scheduled for removal in v7.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->