### PR TITLE
ci: split test job into parallel unit+core (A) and integration (B) groups

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Check Commit Messages (commitlint)
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
-  test:
+  test-a:
+    name: Unit + Core Tests (playground)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,12 +70,53 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
-      - name: Install Sub-App Dependencies
-        run: node scripts/install-apps.mjs
+      - name: Install Playground App
+        run: npm ci
+        working-directory: playground
 
-      - name: Run Tests
-        run: npm test
+      - name: Run Unit Tests
+        run: npm run test:unit
+
+      - name: Run Core E2E Tests
+        run: npx playwright test --config playwright.config.ci-a.ts
 
       - name: Build Project
         run: npm run build
 
+  test-b:
+    name: Integration Tests (external + MUI DataGrid)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Cache Playwright Browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
+
+      - name: Install MUI DataGrid App
+        run: npm ci
+        working-directory: tests/apps/mui-datagrid
+
+      - name: Run Integration Tests
+        run: npx playwright test --config playwright.config.ci-b.ts

--- a/playwright.config.ci-a.ts
+++ b/playwright.config.ci-a.ts
@@ -1,0 +1,35 @@
+// CI Group A: unit tests + all core/playground specs
+// Spins up the playground server only (port 3000).
+// Group B (playwright.config.ci-b.ts) handles external-URL and MUI DataGrid integration tests.
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  // Exclude the specs that belong to Group B (external URLs + MUI DataGrid server)
+  testIgnore: [
+    '**/integration/mui-data-grid.spec.ts',
+    '**/integration/glide.spec.ts',
+    '**/integration/rdg.spec.ts',
+    '**/integration/mui-table.spec.ts',
+  ],
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 2,
+  workers: 2,
+  reporter: 'html',
+  use: {
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: [
+    {
+      command: 'npm run dev',
+      cwd: 'playground',
+      port: 3000,
+      reuseExistingServer: false,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/playwright.config.ci-b.ts
+++ b/playwright.config.ci-b.ts
@@ -1,0 +1,32 @@
+// CI Group B: external-URL integration tests + MUI DataGrid server test
+// Spins up the MUI DataGrid app server only (port 3050).
+// Group A (playwright.config.ci-a.ts) handles unit tests and core/playground specs.
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/integration',
+  testMatch: '**/*.spec.ts',
+  // Exclude the self-contained dedupe test — it lives in Group A
+  testIgnore: [
+    '**/virtualized-horizontal-dedupe.spec.ts',
+  ],
+  fullyParallel: true,
+  forbidOnly: true,
+  retries: 2,
+  workers: 2,
+  reporter: 'html',
+  use: {
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  webServer: [
+    {
+      command: 'npm run dev',
+      cwd: 'tests/apps/mui-datagrid',
+      port: 3050,
+      reuseExistingServer: false,
+      timeout: 120_000,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Replaces the single serial `test` job with two parallel jobs: `test-a` and `test-b`
- Each job only spins up the server it actually needs and installs only its sub-app's dependencies
- `npm test` (local dev) is unchanged

### test-a — Unit + Core Tests (playground server)
- Runs vitest unit tests
- Runs all `tests/*.spec.ts` + `tests/integration/virtualized-horizontal-dedupe.spec.ts` via `playwright.config.ci-a.ts`
- Spins up playground only (port 3000)
- Runs the build

### test-b — Integration Tests (external + MUI DataGrid server)
- Runs `tests/integration/` specs for glide, rdg, mui-table, mui-data-grid via `playwright.config.ci-b.ts`
- Spins up MUI DataGrid app only (port 3050)

## Test plan

- [ ] Verify `test-a` job passes (unit + playground specs)
- [ ] Verify `test-b` job passes (integration specs)
- [ ] Confirm both jobs run in parallel on the PR checks page
- [ ] Update branch protection required checks: add `test-a` and `test-b`, remove old `test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized CI test execution into separate workflows for unit/E2E and integration tests. Improves parallel execution and feedback organization.

* **Chores**
  * Enhanced PR checks with commit message validation. Added TypeScript type checking and hardened TODO/FIXME detection in linting process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->