### PR TITLE
ci: skip test jobs when no source files changed

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,36 @@ on:
       - main
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Check for code changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'playground/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'playwright.config*.ts'
+              - 'scripts/**'
+              - 'vite.config*.ts'
+
   lint:
+    name: Static Analysis & Linting
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +70,8 @@ jobs:
 
   test-a:
     name: Unit + Core Tests (playground)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,6 +116,8 @@ jobs:
 
   test-b:
     name: Integration Tests (external + MUI DataGrid)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What & Why

Docs-only and housekeeping PRs were triggering the full test suite unnecessarily. Adds a `changes` detection job using `dorny/paths-filter` — `test-a` and `test-b` only run when files that can actually affect correctness are touched.

## Closes

(none — CI improvement)

## Paths that trigger tests
- `src/**`, `tests/**`, `playground/**`
- `package.json`, `package-lock.json`
- `tsconfig*.json`, `playwright.config*.ts`, `vite.config*.ts`
- `scripts/**`

## Paths that skip tests (examples)
- `docs/**`
- `.agents/**`
- `README.md`, `CHANGELOG.md`
- `.github/**` workflow files themselves

## Note on branch protection
GitHub treats skipped jobs as passing for required status checks, so `Unit + Core Tests (playground)` and `Integration Tests (external + MUI DataGrid)` will still go green on docs-only PRs.

## Type
- [x] Docs / chore

## Checklist
- [x] `npm run build` succeeds
- [x] CHANGELOG updated (for features / fixes)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow to conditionally execute tests only when code files are modified, improving feedback efficiency and reducing unnecessary pipeline runs on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->