### PR TITLE
chore: skip CodeQL on non-code PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'playground/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig*.json'
+      - 'scripts/**'
+      - 'vite.config*.ts'
   schedule:
     - cron: '0 3 * * 1' # weekly on Monday at 03:00 UTC
 


### PR DESCRIPTION
## Closes
<!-- N/A — maintenance change -->

## Summary
- Adds a `paths` filter to the `pull_request` trigger in `codeql-analysis.yml`
- CodeQL now only runs on PRs that touch source files (same path list as `pr-checks.yml`)
- `push` to `main` and the weekly `schedule` triggers are unaffected — full scans still run there

## Test Plan
- [ ] Open a docs/chore PR — CodeQL job should be skipped
- [ ] Open a source-code PR — CodeQL job should run as normal
- [ ] Existing tests pass (`npm test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CodeQL analysis workflow to run only when relevant file changes occur, improving CI/CD efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->