### PR TITLE
fix: resolve 6 regression bugs (#99 #100 #101 #102 #103 #105)

### DIFF
--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -40,7 +40,9 @@ export class RowFinder<T = any> {
         if (rowLocator) {
             logDebug(this.config, 'info', 'Row found');
             await debugDelay(this.config, 'findRow');
-            return this.makeSmartRow(rowLocator, await this.tableMapper.getMap(), 0);
+            const map = await this.tableMapper.getMap();
+            const rowIndex = await this.resolveRowIndex(rowLocator);
+            return this.makeSmartRow(rowLocator, map, rowIndex);
         }
 
         logDebug(this.config, 'error', 'Row not found', filters);
@@ -55,7 +57,7 @@ export class RowFinder<T = any> {
 
     public async findRows(
         filters: Record<string, FilterValue> = {},
-        options?: { exact?: boolean, maxPages?: number }
+        options?: { exact?: boolean, maxPages?: number, useBulkPagination?: boolean }
     ): Promise<SmartRowArray<T>> {
         const filtersRecord = filters;
         const map = await this.tableMapper.getMap();
@@ -113,8 +115,9 @@ export class RowFinder<T = any> {
                 };
 
                 let paginationResult: boolean | number | PaginationPrimitives | undefined;
-                if (this.config.strategies.pagination?.goNextBulk) {
-                    paginationResult = await this.config.strategies.pagination.goNextBulk(context);
+                const useBulk = options?.useBulkPagination !== false && !!this.config.strategies.pagination?.goNextBulk;
+                if (useBulk) {
+                    paginationResult = await this.config.strategies.pagination.goNextBulk!(context);
                 } else if (this.config.strategies.pagination?.goNext) {
                     paginationResult = await this.config.strategies.pagination.goNext(context);
                 } else {
@@ -212,10 +215,12 @@ export class RowFinder<T = any> {
                 };
 
                 let paginationResult: boolean | number | PaginationPrimitives | undefined;
-                if (this.config.strategies.pagination?.goNextBulk) {
-                    paginationResult = await this.config.strategies.pagination.goNextBulk(context);
-                } else if (this.config.strategies.pagination?.goNext) {
-                    paginationResult = await this.config.strategies.pagination.goNext(context);
+                const pagination = this.config.strategies.pagination;
+                const useBulk = !!pagination?.goNextBulk;
+                if (useBulk && pagination?.goNextBulk) {
+                    paginationResult = await pagination.goNextBulk(context);
+                } else if (pagination?.goNext) {
+                    paginationResult = await pagination.goNext(context);
                 } else {
                     this.log(`Page ${this.tableState.currentPageIndex}: Pagination failed (no goNext or goNextBulk primitive).`);
                     return null;
@@ -234,5 +239,18 @@ export class RowFinder<T = any> {
             }
             return null;
         }
+    }
+
+    private async resolveRowIndex(rowLocator: Locator): Promise<number> {
+        const allRows = await this.resolve(this.config.rowSelector, this.rootLocator).all();
+        const targetHandle = await rowLocator.elementHandle();
+        if (!targetHandle) return 0;
+        for (let i = 0; i < allRows.length; i++) {
+            const handle = await allRows[i].elementHandle();
+            if (handle && await handle.evaluate((el, t) => el === t, targetHandle)) {
+                return i;
+            }
+        }
+        return 0;
     }
 }

--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -147,7 +147,7 @@ export class RowFinder<T = any> {
 
     private async findRowLocator(
         filters: Record<string, FilterValue>,
-        options: { exact?: boolean, maxPages?: number } = {}
+        options: { exact?: boolean, maxPages?: number, useBulkPagination?: boolean } = {}
     ): Promise<Locator | null> {
         const map = await this.tableMapper.getMap();
         const effectiveMaxPages = options.maxPages ?? this.config.maxPages;
@@ -216,7 +216,7 @@ export class RowFinder<T = any> {
 
                 let paginationResult: boolean | number | PaginationPrimitives | undefined;
                 const pagination = this.config.strategies.pagination;
-                const useBulk = !!pagination?.goNextBulk;
+                const useBulk = options.useBulkPagination !== false && !!pagination?.goNextBulk;
                 if (useBulk && pagination?.goNextBulk) {
                     paginationResult = await pagination.goNextBulk(context);
                 } else if (pagination?.goNext) {

--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -17,7 +17,7 @@ export class RowFinder<T = any> {
         resolve: (item: Selector, parent: Locator | Page) => Locator,
         private filterEngine: FilterEngine,
         private tableMapper: TableMapper,
-        private makeSmartRow: (loc: Locator, map: Map<string, number>, index: number, tablePageIndex?: number) => SmartRow<T>,
+        private makeSmartRow: (loc: Locator, map: Map<string, number>, index: number | undefined, tablePageIndex?: number) => SmartRow<T>,
         private tableState: { currentPageIndex: number } = { currentPageIndex: 0 }
     ) {
         this.resolve = resolve;
@@ -241,16 +241,16 @@ export class RowFinder<T = any> {
         }
     }
 
-    private async resolveRowIndex(rowLocator: Locator): Promise<number> {
+    private async resolveRowIndex(rowLocator: Locator): Promise<number | undefined> {
         const allRows = await this.resolve(this.config.rowSelector, this.rootLocator).all();
         const targetHandle = await rowLocator.elementHandle();
-        if (!targetHandle) return 0;
+        if (!targetHandle) return undefined;
         for (let i = 0; i < allRows.length; i++) {
             const handle = await allRows[i].elementHandle();
             if (handle && await handle.evaluate((el, t) => el === t, targetHandle)) {
                 return i;
             }
         }
-        return 0;
+        return undefined;
     }
 }

--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -42,7 +42,7 @@ export class RowFinder<T = any> {
             await debugDelay(this.config, 'findRow');
             const map = await this.tableMapper.getMap();
             const rowIndex = await this.resolveRowIndex(rowLocator);
-            return this.makeSmartRow(rowLocator, map, rowIndex);
+            return this.makeSmartRow(rowLocator, map, rowIndex, this.tableState.currentPageIndex);
         }
 
         logDebug(this.config, 'error', 'Row not found', filters);

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -95,9 +95,8 @@ export const muiTable: Partial<TableConfig> = {
                 const prevBtn = root.locator('button[aria-label="Go to previous page"]');
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
 
-                let maxRetries = 50;
                 let clicked = false;
-                while (maxRetries-- > 0 && await prevBtn.count() > 0 && !(await prevBtn.isDisabled())) {
+                while (await prevBtn.count() > 0 && !(await prevBtn.isDisabled())) {
                     const oldText = await displayedRows.innerText().catch(() => '');
                     await prevBtn.click();
                     await waitForMuiPaginationStabilization(context, displayedRows, oldText);

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -111,7 +111,7 @@ export const muiTable: Partial<TableConfig> = {
                         noProgressCount++;
                         if (noProgressCount >= NO_PROGRESS_LIMIT) {
                             logDebug(context.config, 'error', `goToFirst: no pagination progress after ${NO_PROGRESS_LIMIT} consecutive clicks — aborting to avoid infinite loop`);
-                            break;
+                            return false;
                         }
                     } else {
                         noProgressCount = 0;

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -1,6 +1,7 @@
 import { Locator } from '@playwright/test';
 import { TableConfig, TableContext } from '../types';
 import { PaginationStrategies } from '../strategies';
+import { logDebug } from '../utils/debugUtils';
 
 /** 
  * Safely wait for MUI pagination to stabilize.
@@ -96,11 +97,25 @@ export const muiTable: Partial<TableConfig> = {
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
 
                 let clicked = false;
+                let noProgressCount = 0;
+                const NO_PROGRESS_LIMIT = 3;
+
                 while (await prevBtn.count() > 0 && !(await prevBtn.isDisabled())) {
                     const oldText = await displayedRows.innerText().catch(() => '');
                     await prevBtn.click();
                     await waitForMuiPaginationStabilization(context, displayedRows, oldText);
                     clicked = true;
+
+                    const newText = await displayedRows.innerText().catch(() => '');
+                    if (newText === oldText) {
+                        noProgressCount++;
+                        if (noProgressCount >= NO_PROGRESS_LIMIT) {
+                            logDebug(context.config, 'error', `goToFirst: no pagination progress after ${NO_PROGRESS_LIMIT} consecutive clicks — aborting to avoid infinite loop`);
+                            break;
+                        }
+                    } else {
+                        noProgressCount = 0;
+                    }
                 }
                 return clicked;
             }

--- a/src/smartRow.ts
+++ b/src/smartRow.ts
@@ -593,7 +593,9 @@ const createSmartRow = <T = any>(
 
     smart.bringIntoView = async (): Promise<void> => {
         if (rowIndex === undefined) {
-            throw new Error('Cannot bring row into view - row index is unknown. Use getRowByIndex() instead of getRow().');
+            logDebug(config, 'info', 'bringIntoView called on a row with unknown rowIndex (e.g. from getRow()). ' +
+                'Page navigation and scrolling will proceed, but virtual-scroll keyboard navigation will be skipped. ' +
+                'Use findRow() if you need accurate rowIndex.');
         }
 
         const parentTable = smart.table as TableResult<T>;

--- a/src/strategies/stabilization.ts
+++ b/src/strategies/stabilization.ts
@@ -77,10 +77,23 @@ export const StabilizationStrategies = {
      */
     networkIdle: (options: { spinnerSelector?: string, timeout?: number } = {}): StabilizationStrategy => {
         return async ({ root, page, resolve }, action) => {
-            await action();
             const timeout = options.timeout ?? 5000;
             if (options.spinnerSelector) {
                 const spinner = resolve(options.spinnerSelector, root);
+                const existedBefore = await spinner.count() > 0;
+
+                await action();
+
+                if (!existedBefore) {
+                    // Spinner wasn't present before action — wait briefly for it to appear
+                    // so we don't declare success before the loading cycle even starts
+                    const appearDeadline = Date.now() + 500;
+                    while (Date.now() < appearDeadline && await spinner.count() === 0) {
+                        await page.waitForTimeout(50);
+                    }
+                    if (await spinner.count() === 0) return true; // spinner never appeared
+                }
+
                 try {
                     await spinner.waitFor({ state: 'detached', timeout });
                     return true;
@@ -89,6 +102,7 @@ export const StabilizationStrategies = {
                 }
             }
             // Fallback to simple wait if no selector
+            await action();
             await page.waitForTimeout(500);
             return true;
         }

--- a/src/strategies/stabilization.ts
+++ b/src/strategies/stabilization.ts
@@ -76,7 +76,8 @@ export const StabilizationStrategies = {
      * Useful for tables that have explicit loading states but might not change content immediately.
      */
     networkIdle: (options: { spinnerSelector?: string, timeout?: number } = {}): StabilizationStrategy => {
-        return async ({ root, page, resolve }) => {
+        return async ({ root, page, resolve }, action) => {
+            await action();
             const timeout = options.timeout ?? 5000;
             if (options.spinnerSelector) {
                 const spinner = resolve(options.spinnerSelector, root);

--- a/src/typeContext.ts
+++ b/src/typeContext.ts
@@ -647,7 +647,7 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    */
   findRows: (
     filters?: Record<string, FilterValue>,
-    options?: { exact?: boolean, maxPages?: number }
+    options?: { exact?: boolean, maxPages?: number, useBulkPagination?: boolean }
   ) => Promise<SmartRowArray<T>>;
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -647,7 +647,7 @@ export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; 
    */
   findRows: (
     filters?: Record<string, FilterValue>,
-    options?: { exact?: boolean, maxPages?: number }
+    options?: { exact?: boolean, maxPages?: number, useBulkPagination?: boolean }
   ) => Promise<SmartRowArray<T>>;
 
   /**

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -359,7 +359,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
         rootLocator
       );
       const rowLocator = matchedRows.first();
-      return _makeSmart(rowLocator, map, 0); // fallback index 0
+      return _makeSmart(rowLocator, map, undefined); // sync path cannot compute real index
     },
 
     getRowByIndex: (index: number): SmartRowType<T> => {
@@ -378,7 +378,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
 
 
 
-    findRows: async (filters?: Record<string, FilterValue>, options?: { exact?: boolean, maxPages?: number }): Promise<SmartRowArray<T>> => {
+    findRows: async (filters?: Record<string, FilterValue>, options?: { exact?: boolean, maxPages?: number, useBulkPagination?: boolean }): Promise<SmartRowArray<T>> => {
       log(`findRows: filters=${safeStringify(filters ?? {})} options=${safeStringify(options)}`);
       return rowFinder.findRows(filters ?? {}, options);
     },

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -4,7 +4,7 @@ import { TYPE_CONTEXT } from './typeContext';
 import { MINIMAL_CONFIG_CONTEXT } from './minimalConfigContext';
 import { SortingStrategies as ImportedSortingStrategies } from './strategies/sorting';
 import { PaginationStrategies as ImportedPaginationStrategies } from './strategies/pagination';
-import { validatePaginationResult } from './strategies/validation';
+import { validatePaginationResult, validateSortingStrategy, validateFillStrategy } from './strategies/validation';
 
 import { DedupeStrategies as ImportedDedupeStrategies } from './strategies/dedupe';
 import { LoadingStrategies as ImportedLoadingStrategies } from './strategies/loading';
@@ -230,6 +230,9 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
     init: async (options?: { timeout?: number }): Promise<TableResult<T>> => {
       if (tableMapper.isInitialized()) return result;
 
+      if (config.strategies.sorting) validateSortingStrategy(config.strategies.sorting);
+      if (config.strategies.fill) validateFillStrategy(config.strategies.fill);
+
       warnIfDebugInCI(config);
       logDebug(config, 'info', 'Initializing table');
 
@@ -403,7 +406,10 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           await config.strategies.sorting.doSort({ columnName, direction, context });
 
           if (config.strategies.loading?.isTableLoading) {
-            await config.strategies.loading.isTableLoading(context);
+            const deadline = Date.now() + 10000;
+            while (Date.now() < deadline && await config.strategies.loading.isTableLoading(context)) {
+              await rootLocator.page().waitForTimeout(100);
+            }
           } else {
             await rootLocator.page().waitForTimeout(200);
           }

--- a/tests/bug-regression.spec.ts
+++ b/tests/bug-regression.spec.ts
@@ -93,7 +93,7 @@ test.describe('Bug #101: findRows() always uses goNextBulk even when bulk is dis
     }).init();
 
     // Pass useBulkPagination: false — findRows should prefer goNext
-    await table.findRows({}, { useBulkPagination: false } as any);
+    await table.findRows({}, { useBulkPagination: false });
 
     expect(goNextBulkCalled).toBe(0);
     expect(goNextCalled).toBe(1);

--- a/tests/bug-regression.spec.ts
+++ b/tests/bug-regression.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for bugs found via the GBU review flow.
+ * Each test is named with its issue number and is written to FAIL against the
+ * buggy code and PASS once the fix is applied.
+ */
+import { test, expect } from '@playwright/test';
+import { useTable } from '../src/index';
+
+// ─── Shared HTML fixtures ─────────────────────────────────────────────────────
+
+const SIMPLE_TABLE_HTML = `
+  <table id="t">
+    <thead><tr><th>Name</th></tr></thead>
+    <tbody>
+      <tr><td>Alice</td></tr>
+      <tr><td>Bob</td></tr>
+      <tr><td>Carol</td></tr>
+      <tr><td>Dave</td></tr>
+      <tr><td>Eve</td></tr>
+    </tbody>
+  </table>
+`;
+
+// ─── Bug #103: getRow() / findRow() always assign rowIndex: 0 ─────────────────
+
+test.describe('Bug #103: rowIndex is 0 for every matched row', () => {
+  test('getRow() returns the correct rowIndex for a non-first match', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+    const table = await useTable(page.locator('#t')).init();
+
+    const carol = table.getRow({ Name: 'Carol' });
+    expect(carol.rowIndex).toBe(2); // 0-indexed; Alice=0, Bob=1, Carol=2
+
+    const eve = table.getRow({ Name: 'Eve' });
+    expect(eve.rowIndex).toBe(4);
+  });
+
+  test('findRow() returns the correct rowIndex for a non-first match', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+    const table = await useTable(page.locator('#t')).init();
+
+    const dave = await table.findRow({ Name: 'Dave' });
+    expect(dave.rowIndex).toBe(3);
+  });
+});
+
+// ─── Bug #100: validateSortingStrategy / validateFillStrategy never called ────
+
+test.describe('Bug #100: malformed strategies only fail at call-time, not at init()', () => {
+  test('init() throws early for a sorting strategy missing getSortState', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+
+    const table = useTable(page.locator('#t'), {
+      strategies: {
+        sorting: { doSort: async () => {} } as any, // getSortState intentionally absent
+      },
+    });
+
+    // Should throw during init(), not silently succeed then blow up on first sort
+    await expect(table.init()).rejects.toThrow(/getSortState/);
+  });
+
+  test('init() throws early for a fill strategy that is not a function', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+
+    const table = useTable(page.locator('#t'), {
+      strategies: {
+        fill: { someKey: true } as any,
+      },
+    });
+
+    await expect(table.init()).rejects.toThrow(/Fill strategy must be a function/);
+  });
+});
+
+// ─── Bug #101: findRows() ignores useBulkPagination, always prefers goNextBulk ─
+
+test.describe('Bug #101: findRows() always uses goNextBulk even when bulk is disabled', () => {
+  test('findRows() calls goNext (not goNextBulk) when useBulkPagination: false', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+
+    let goNextCalled = 0;
+    let goNextBulkCalled = 0;
+
+    const table = await useTable(page.locator('#t'), {
+      strategies: {
+        pagination: {
+          goNext: async () => { goNextCalled++; return false; },      // single-page step
+          goNextBulk: async () => { goNextBulkCalled++; return false; }, // bulk step
+        },
+      },
+    }).init();
+
+    // Pass useBulkPagination: false — findRows should prefer goNext
+    await table.findRows({}, { useBulkPagination: false } as any);
+
+    expect(goNextBulkCalled).toBe(0);
+    expect(goNextCalled).toBe(1);
+  });
+});
+
+// ─── Bug #99: sorting stabilization polls isTableLoading once, result ignored ─
+
+test.describe('Bug #99: sorting.apply() calls isTableLoading once instead of looping', () => {
+  test('sorting.apply() polls isTableLoading until it returns false before checking sort state', async ({ page }) => {
+    await page.setContent(SIMPLE_TABLE_HTML);
+
+    let isLoadingCallCount = 0;
+    let doSortCallCount = 0;
+
+    const table = await useTable(page.locator('#t'), {
+      strategies: {
+        sorting: {
+          // doSort completes immediately, but the table only "appears sorted"
+          // after isTableLoading has been called at least 3 times
+          doSort: async () => { doSortCallCount++; },
+          getSortState: async () => (isLoadingCallCount >= 3 ? 'asc' : 'none'),
+        },
+        loading: {
+          // Simulates a slow render: busy for the first two calls, done on the third
+          isTableLoading: async () => {
+            isLoadingCallCount++;
+            return isLoadingCallCount < 3;
+          },
+        },
+      },
+    }).init();
+
+    await table.sorting.apply('Name', 'asc');
+
+    // With the fix: isTableLoading is polled until false → doSort runs exactly once
+    // With the bug: isTableLoading is called once per retry → doSort runs 3 times
+    expect(doSortCallCount).toBe(1);
+    expect(isLoadingCallCount).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/tests/bug-regression.spec.ts
+++ b/tests/bug-regression.spec.ts
@@ -29,10 +29,10 @@ test.describe('Bug #103: rowIndex is 0 for every matched row', () => {
     const table = await useTable(page.locator('#t')).init();
 
     const carol = table.getRow({ Name: 'Carol' });
-    expect(carol.rowIndex).toBe(2); // 0-indexed; Alice=0, Bob=1, Carol=2
+    expect(carol.rowIndex).toBeUndefined(); // sync path cannot compute real index
 
     const eve = table.getRow({ Name: 'Eve' });
-    expect(eve.rowIndex).toBe(4);
+    expect(eve.rowIndex).toBeUndefined();
   });
 
   test('findRow() returns the correct rowIndex for a non-first match', async ({ page }) => {
@@ -83,6 +83,7 @@ test.describe('Bug #101: findRows() always uses goNextBulk even when bulk is dis
     let goNextBulkCalled = 0;
 
     const table = await useTable(page.locator('#t'), {
+      maxPages: 2,
       strategies: {
         pagination: {
           goNext: async () => { goNextCalled++; return false; },      // single-page step

--- a/tests/integration/mui-table.spec.ts
+++ b/tests/integration/mui-table.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import path from 'path';
 import { useTable, presets } from '../../src/index';
 
 test.describe('MUI Table Preset Integration', () => {
@@ -73,5 +74,35 @@ test.describe('MUI Table Preset Integration', () => {
         // Calling findRows() with no filters should scrape all pages and return every row.
         const allRows = await table.findRows();
         expect(allRows.length).toBeGreaterThan(5);
+    });
+});
+
+// ─── Bug #105: muiTable.goToFirst() silently fails if table has more than 50 pages
+
+test.describe('Bug #105: goToFirst() 50-retry cap', () => {
+    // Uses a synthetic page that starts on page 55 of 55.
+    // Returning to page 1 requires 54 previous-page clicks — exceeds the hardcoded cap of 50.
+    const fixtureUrl = `file://${path.resolve(__dirname, '../test-assets/mui-pagination-55pages.html')}`;
+
+    test('goToFirst() reaches page 1 when the table has more than 50 pages', async ({ page }) => {
+        await page.goto(fixtureUrl);
+
+        // Confirm we start on the last page (rows 271–275 of 275)
+        await expect(page.locator('.MuiTablePagination-displayedRows')).toContainText('271');
+
+        const context: any = {
+            root: page.locator('#table-wrapper'),
+            page,
+            config: { strategies: {} },
+            resolve: (selector: string, root: any) => root.locator(selector),
+        };
+
+        const goToFirst = (presets.muiTable as any).strategies.pagination.goToFirst;
+        const result = await goToFirst(context);
+
+        expect(result).toBe(true);
+        // After a successful goToFirst, the display must show rows starting at exactly 1
+        // (e.g. "1–5 of 275"). A loose contains('1–') would also match "21–25", so use a regex.
+        await expect(page.locator('.MuiTablePagination-displayedRows')).toHaveText(/^1[–\-]/);
     });
 });

--- a/tests/integration/mui-table.spec.ts
+++ b/tests/integration/mui-table.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
+import { Locator } from '@playwright/test';
 import path from 'path';
-import { useTable, presets } from '../../src/index';
+import { useTable, presets, TableContext } from '../../src/index';
 
 test.describe('MUI Table Preset Integration', () => {
 
@@ -90,14 +91,14 @@ test.describe('Bug #105: goToFirst() 50-retry cap', () => {
         // Confirm we start on the last page (rows 271–275 of 275)
         await expect(page.locator('.MuiTablePagination-displayedRows')).toContainText('271');
 
-        const context: any = {
+        const context: TableContext = {
             root: page.locator('#table-wrapper'),
             page,
-            config: { strategies: {} },
-            resolve: (selector: string, root: any) => root.locator(selector),
+            config: { strategies: {} } as TableContext['config'],
+            resolve: (selector, root) => (root as Locator).locator(selector as string),
         };
 
-        const goToFirst = (presets.muiTable as any).strategies.pagination.goToFirst;
+        const goToFirst = presets.muiTable.strategies!.pagination!.goToFirst!;
         const result = await goToFirst(context);
 
         expect(result).toBe(true);

--- a/tests/test-assets/mui-pagination-55pages.html
+++ b/tests/test-assets/mui-pagination-55pages.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Synthetic MUI Pagination – 55 pages</title>
+  <style>
+    body { font-family: sans-serif; padding: 16px; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 6px 12px; }
+    .MuiTablePagination-root { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+    button:disabled { opacity: 0.4; cursor: default; }
+  </style>
+</head>
+<body>
+  <div id="table-wrapper" class="MuiPaper-root">
+    <table id="main-table">
+      <thead><tr><th>Name</th></tr></thead>
+      <tbody><tr><td>Row A</td></tr></tbody>
+    </table>
+    <div class="MuiTablePagination-root">
+      <span class="MuiTablePagination-displayedRows" id="page-display"></span>
+      <button aria-label="Go to previous page" id="prev-btn">‹ Prev</button>
+    </div>
+  </div>
+
+  <script>
+    // 55 pages of 5 rows each = 275 rows total. Start on the last page (index 54).
+    const TOTAL_PAGES = 55;
+    const ROWS_PER_PAGE = 5;
+    const TOTAL_ROWS = TOTAL_PAGES * ROWS_PER_PAGE;
+
+    let currentPage = TOTAL_PAGES - 1; // 0-indexed
+
+    function render() {
+      const start = currentPage * ROWS_PER_PAGE + 1;
+      const end = Math.min((currentPage + 1) * ROWS_PER_PAGE, TOTAL_ROWS);
+      document.getElementById('page-display').textContent =
+        start + '–' + end + ' of ' + TOTAL_ROWS;
+      document.getElementById('prev-btn').disabled = currentPage === 0;
+    }
+
+    document.getElementById('prev-btn').addEventListener('click', function () {
+      if (currentPage > 0) {
+        currentPage--;
+        render();
+      }
+    });
+
+    render();
+  </script>
+</body>
+</html>

--- a/tests/unit/stabilization.unit.test.ts
+++ b/tests/unit/stabilization.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { StabilizationStrategies } from '../../src/strategies/stabilization';
+import type { TableContext } from '../../src/types';
+
+function makeMockContext(overrides: Partial<TableContext> = {}): TableContext {
+  return {
+    root: {} as any,
+    page: {
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      waitForLoadState: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    resolve: vi.fn() as any,
+    config: { strategies: {} } as any,
+    ...overrides,
+  };
+}
+
+// Bug #102: StabilizationStrategies.networkIdle never calls action()
+// The inner async function was missing the `action` parameter entirely.
+describe('StabilizationStrategies.networkIdle', () => {
+  it('calls action() (fallback path, no spinnerSelector)', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeMockContext();
+    const strategy = StabilizationStrategies.networkIdle();
+
+    await strategy(ctx, action);
+
+    expect(action).toHaveBeenCalledOnce();
+  });
+
+  it('calls action() when spinnerSelector is provided', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const mockSpinner = { waitFor: vi.fn().mockResolvedValue(undefined) };
+    const ctx = makeMockContext({
+      resolve: vi.fn().mockReturnValue(mockSpinner) as any,
+    });
+    const strategy = StabilizationStrategies.networkIdle({ spinnerSelector: '.loading-spinner' });
+
+    await strategy(ctx, action);
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(mockSpinner.waitFor).toHaveBeenCalledWith({ state: 'detached', timeout: 5000 });
+  });
+
+  it('still returns true after calling action()', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeMockContext();
+    const strategy = StabilizationStrategies.networkIdle();
+
+    const result = await strategy(ctx, action);
+
+    expect(result).toBe(true);
+  });
+});

--- a/tests/unit/stabilization.unit.test.ts
+++ b/tests/unit/stabilization.unit.test.ts
@@ -30,7 +30,11 @@ describe('StabilizationStrategies.networkIdle', () => {
 
   it('calls action() when spinnerSelector is provided', async () => {
     const action = vi.fn().mockResolvedValue(undefined);
-    const mockSpinner = { waitFor: vi.fn().mockResolvedValue(undefined) };
+    const mockSpinner = {
+      // First call: absent before action; subsequent calls: present after action appears
+      count: vi.fn().mockResolvedValueOnce(0).mockResolvedValue(1),
+      waitFor: vi.fn().mockResolvedValue(undefined),
+    };
     const ctx = makeMockContext({
       resolve: vi.fn().mockReturnValue(mockSpinner) as any,
     });


### PR DESCRIPTION
## Summary

- **#102** `networkIdle` stabilization strategy never called `action()` — the inner function was missing the `action` parameter entirely
- **#105** `goToFirst()` in the MUI preset had a 50-retry cap, causing it to stop mid-navigation on tables with >50 pages
- **#99** `sorting.apply()` called `isTableLoading` once and discarded the result; now polls until it returns `false`
- **#100** `validateSortingStrategy` and `validateFillStrategy` were never called; malformed strategies only blew up at call-time — now validated eagerly in `init()`
- **#101** `findRows()` always called `goNextBulk` when present, ignoring the `useBulkPagination` flag; the flag is now respected and exposed in the public API
- **#103** `findRow()` always assigned `rowIndex: 0`; now resolves the real DOM position via element handle comparison. `getRow()` (synchronous) can't compute the index, so it now returns `undefined` instead of the wrong value `0`

Each bug has a corresponding regression test that fails against the unfixed code and passes after the fix.

## Test plan

- [x] `tests/unit/stabilization.unit.test.ts` — #102 (3 Vitest tests)
- [x] `tests/integration/mui-table.spec.ts` — #105 (Playwright, 55-page fixture)
- [x] `tests/bug-regression.spec.ts` — #99, #100, #101, #103 (6 Playwright tests)
- [x] All 116 existing unit tests pass (`npx vitest run tests/unit/`)
- [x] Full E2E suite passes (`npx playwright test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional bulk pagination for faster multi-page row searches.
  * Stabilization strategies now accept and run an action before waiting for load indicators.

* **Bug Fixes**
  * Correct row-index detection for non-first matches.
  * bringIntoView no longer throws when a row’s index is unknown.
  * More robust “go to first” pagination and repeated polling for table loading during sorting.

* **Tests**
  * Added regression, integration, unit tests and a 55-page pagination fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->