### PR TITLE
chore: ignore dependabot commits in commitlint

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,3 +1,5 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  // Ignore Dependabot commits as they often violate body line length with long URLs
+  ignores: [(message) => message.includes('Signed-off-by: dependabot[bot]')],
 };


### PR DESCRIPTION
Fixes the GHA failure where Dependabot's grouped update commit messages exceed the body line length limit.