### PR TITLE
chore: schedule dependabot for 08:00 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "08:00"
     open-pull-requests-limit: 1
     labels:
       - "dependencies"
@@ -32,6 +33,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "thursday"
+      time: "08:00"
     open-pull-requests-limit: 1
     labels:
       - "dependencies"


### PR DESCRIPTION
Sets the schedule time for Dependabot updates to 08:00 UTC (4 AM EDT) to avoid active working hours and CodeRabbit credit usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to specify a consistent time for running dependency and GitHub Actions update checks on their scheduled days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->