### PR TITLE
fix: avoid PR body interpolation into JS template literal in automerge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,8 +14,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Get PR body
-        id: check-dependabot
+      - name: Check for major version bumps
+        id: check-major
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,15 +25,7 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,
             });
-            core.setOutput('body', pr.data.body || '');
-
-      - name: Check for major version bumps
-        id: check-major
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const body = `${{ steps.check-dependabot.outputs.body }}`;
+            const body = pr.data.body || '';
             const regex = /from\s+([0-9]+)\.([0-9]+)\.([0-9]+)[^\n]*to\s+([0-9]+)\.([0-9]+)\.([0-9]+)/ig;
             let m;
             while ((m = regex.exec(body)) !== null) {


### PR DESCRIPTION
## Summary

- Collapses the two `github-script` steps in the Dependabot auto-merge workflow into one
- Reads `pr.data.body` directly instead of interpolating it through `core.setOutput` → template literal

## Root cause

The `check-major` step did:
\`\`\`js
const body = `${{ steps.check-dependabot.outputs.body }}`;
\`\`\`

Dependabot PR bodies contain markdown backticks (e.g. \`pnpm\`, \`pnpm-lock.yaml\`). When interpolated at workflow-render time, those backticks terminated the JS template literal early, leaving bare identifiers like `pnpm` that caused `SyntaxError: Unexpected identifier 'pnpm'`.

## Test plan

- [ ] Merge a Dependabot non-major PR and confirm `enable-automerge` job succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)