### PR TITLE
fix: use vitest directly in publish CI to reliably generate test-results.json

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run Unit Tests
         if: steps.check_version.outputs.changed == 'true'
-        run: pnpm run test:unit -- --reporter=json --outputFile.json=test-results.json
+        run: pnpm exec vitest run --reporter=verbose --reporter=json --outputFile=test-results.json
 
       - name: Test Packaging
         if: steps.check_version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

- Replaces `pnpm run test:unit -- --reporter=json --outputFile.json=test-results.json` with a direct `pnpm exec vitest run --reporter=verbose --reporter=json --outputFile=test-results.json`

## Root cause

`pnpm run test:unit` composes a vitest command that already includes `--reporter=verbose --reporter=html`. Appending `-- --reporter=json --outputFile.json=test-results.json` adds a third reporter and relies on the dotted `--outputFile.json=` CLI form to target only the json reporter's output file. That form is not reliably parsed as a CLI passthrough in Vitest 3.x, so `test-results.json` was never written.

## Fix

Call vitest directly with exactly the reporters needed:
- `--reporter=verbose` → stdout (CI logs)
- `--reporter=json --outputFile=test-results.json` → file (metrics input)

Single run, atomic — if tests fail the JSON is not produced and the downstream `Collect Library Metrics` step is protected by its existing `success()` guard.

## Test plan

- [ ] Merge and confirm `publish-gpr` writes `test-results.json` and `Collect Library Metrics` succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)