### PR TITLE
fix(viewport): skip scrollToRow in synchronized/parallel mode; reuse colRange

### DIFF
--- a/src/smartRow.ts
+++ b/src/smartRow.ts
@@ -79,18 +79,18 @@ const _navigateToCell = async (params: {
     // Runs before navigation primitives; falls through to them if cell still not accessible.
     const viewport = config.strategies.viewport;
     if (viewport && typeof rowIndex === 'number') {
-        // Fast path via range oracle: if the user provides getVisibleColumnRange (and memoizes it),
-        // this check is a near-instant JS lookup — no DOM count() round-trip needed.
+        // Fast path via range oracle: re-used below to avoid a second DOM round-trip.
         // Rows do NOT sync at the barrier here — only scroll boundaries need coordination.
+        let knownColRange: { first: number; last: number } | null = null;
         if (viewport.getVisibleColumnRange) {
-            const colRange = await viewport.getVisibleColumnRange(context);
-            if (colRange && index >= colRange.first && index <= colRange.last) {
+            knownColRange = await viewport.getVisibleColumnRange(context);
+            if (knownColRange && index >= knownColRange.first && index <= knownColRange.last) {
                 const rowRange = viewport.getVisibleRowRange
                     ? await viewport.getVisibleRowRange(context)
                     : null;
                 const rowVisible = !rowRange || (rowIndex >= rowRange.first && rowIndex <= rowRange.last);
                 if (rowVisible && await targetReached()) {
-                    logDebug(config, 'verbose', `_navigateToCell: col ${index} in visible range [${colRange.first}-${colRange.last}], reading directly`);
+                    logDebug(config, 'verbose', `_navigateToCell: col ${index} in visible range [${knownColRange.first}-${knownColRange.last}], reading directly`);
                     return getCellLocator();
                 }
             }
@@ -103,9 +103,10 @@ const _navigateToCell = async (params: {
         // Column is out of view. Scroll to bring it in.
         // In synchronized mode, the last row to arrive triggers the scroll once for all rows.
         const scrollIntoViewport = async () => {
-            const colRange = viewport.getVisibleColumnRange
+            // Reuse the range fetched during the fast-path check; re-query only if unknown.
+            const colRange = knownColRange ?? (viewport.getVisibleColumnRange
                 ? await viewport.getVisibleColumnRange(context)
-                : null;
+                : null);
             const colOutOfView = !colRange || index < colRange.first || index > colRange.last;
 
             if (colOutOfView) {
@@ -122,15 +123,14 @@ const _navigateToCell = async (params: {
                 return;
             }
 
-            // 2D scroll hazard guard: scrolling horizontally may have unmounted the target row.
-            const rowRange = viewport.getVisibleRowRange
-                ? await viewport.getVisibleRowRange(context)
-                : null;
-            const rowOutOfView = rowRange && (rowIndex < rowRange.first || rowIndex > rowRange.last);
-
-            if (rowOutOfView) {
-                logDebug(config, 'verbose', `_navigateToCell: row ${rowIndex} out of view after col scroll, recovering`);
-                if (viewport.scrollToRow) {
+            // 2D scroll hazard: horizontal scroll may evict the target row from the DOM.
+            // scrollToRow moves the viewport to one specific row, which would evict every
+            // other row in the same barrier batch — only safe in sequential (no-barrier) mode.
+            if (!barrier && viewport.scrollToRow && viewport.getVisibleRowRange) {
+                const rowRange = await viewport.getVisibleRowRange(context);
+                const rowOutOfView = rowRange && (rowIndex < rowRange.first || rowIndex > rowRange.last);
+                if (rowOutOfView) {
+                    logDebug(config, 'verbose', `_navigateToCell: row ${rowIndex} out of view after col scroll, recovering`);
                     await viewport.scrollToRow(context, rowIndex);
                 }
             }

--- a/src/smartRow.ts
+++ b/src/smartRow.ts
@@ -125,8 +125,8 @@ const _navigateToCell = async (params: {
 
             // 2D scroll hazard: horizontal scroll may evict the target row from the DOM.
             // scrollToRow moves the viewport to one specific row, which would evict every
-            // other row in the same barrier batch — only safe in sequential (no-barrier) mode.
-            if (!barrier && viewport.scrollToRow && viewport.getVisibleRowRange) {
+            // other row in a parallel batch — safe only when there are no peers to evict.
+            if ((!barrier || !barrier.isParallel()) && viewport.scrollToRow && viewport.getVisibleRowRange) {
                 const rowRange = await viewport.getVisibleRowRange(context);
                 const rowOutOfView = rowRange && (rowIndex < rowRange.first || rowIndex > rowRange.last);
                 if (rowOutOfView) {

--- a/src/utils/navigationBarrier.ts
+++ b/src/utils/navigationBarrier.ts
@@ -12,6 +12,11 @@ export class NavigationBarrier {
     this.total = total;
   }
 
+  /** True when more than one row shares this barrier (scrollToRow would evict peers). */
+  isParallel(): boolean {
+    return this.total > 1;
+  }
+
   /**
    * Synchronize all active rows at a specific column index.
    * The last row to arrive will trigger the `moveAction`.

--- a/tests/viewport-strategy.spec.ts
+++ b/tests/viewport-strategy.spec.ts
@@ -1,0 +1,277 @@
+import { test, expect } from '@playwright/test';
+import { useTable, Strategies } from '../src';
+
+// ─── Shared HTML builders ──────────────────────────────────────────────────────
+
+/**
+ * Builds an HTML page with a horizontally virtualized table.
+ * Columns 1–3 always present; column 4 (Country) mounts when scrollLeft >= 200.
+ * Rows are NOT evicted by horizontal scrolling (1D horizontal virtualization only).
+ */
+function makeHorizontalVirtHtml(rowCount: number) {
+    const rows = Array.from({ length: rowCount }, (_, i) => `
+        <div role="row" class="row" aria-rowindex="${i + 2}" style="top: ${i * 30}px;">
+            <div role="gridcell" aria-colindex="1" class="cell col-1">${i + 1}</div>
+            <div role="gridcell" aria-colindex="2" class="cell col-2">Name-${i + 1}</div>
+            <div role="gridcell" aria-colindex="3" class="cell col-3">email${i + 1}@test.com</div>
+        </div>`).join('\n');
+
+    return `<!DOCTYPE html><html>
+        <style>
+            .table-container { width: 300px; height: 200px; overflow: auto; position: relative; }
+            .viewport { width: 500px; }
+            .grid { display: block; position: relative; }
+            .header { display: flex; position: sticky; top: 0; background: #eee; }
+            .row { display: flex; border-bottom: 1px solid #ddd; position: absolute; width: 100%; height: 30px; }
+            .cell { position: absolute; width: 120px; padding: 5px; box-sizing: border-box; background: white; }
+            .col-1 { left: 0px; } .col-2 { left: 120px; } .col-3 { left: 240px; } .col-4 { left: 360px; }
+        </style>
+        <body>
+            <div class="table-container" id="scroller">
+                <div class="viewport">
+                    <div role="grid" class="grid">
+                        <div class="header" role="row">
+                            <div role="columnheader" aria-colindex="1" class="cell col-1">ID</div>
+                            <div role="columnheader" aria-colindex="2" class="cell col-2">Name</div>
+                            <div role="columnheader" aria-colindex="3" class="cell col-3">Email</div>
+                        </div>
+                        ${rows}
+                    </div>
+                </div>
+            </div>
+            <script>
+                const scroller = document.getElementById('scroller');
+                const COUNTRIES = ['USA','Canada','UK','Germany','France','Japan','Brazil','Australia','India','Mexico'];
+                scroller.addEventListener('scroll', () => {
+                    const header = document.querySelector('.header[role="row"]');
+                    const rows = document.querySelectorAll('.row[aria-rowindex]');
+                    if (scroller.scrollLeft >= 200) {
+                        if (!header.querySelector('[aria-colindex="4"]')) {
+                            const th = document.createElement('div');
+                            th.setAttribute('role','columnheader'); th.setAttribute('aria-colindex','4');
+                            th.className = 'cell col-4 mounted-col4';
+                            th.innerText = 'Country'; header.appendChild(th);
+                        }
+                        rows.forEach((r, i) => {
+                            if (!r.querySelector('[aria-colindex="4"]')) {
+                                const cell = document.createElement('div');
+                                cell.setAttribute('role','gridcell'); cell.setAttribute('aria-colindex','4');
+                                cell.className = 'cell col-4 mounted-col4';
+                                cell.innerText = COUNTRIES[i % COUNTRIES.length]; r.appendChild(cell);
+                            }
+                        });
+                    } else {
+                        document.querySelectorAll('.mounted-col4').forEach(c => c.remove());
+                    }
+                });
+            </script>
+        </body></html>`;
+}
+
+/**
+ * Builds a 2D virtualized table: columns AND rows are evicted based on scroll position.
+ * - Column 4 mounts when scrollLeft >= 150.
+ * - Only rows whose aria-rowindex falls within the current vertical window are in the DOM.
+ * The vertical window shifts when the user scrolls horizontally (simulating CSS Grid RDG
+ * behaviour where the whole grid re-renders on any scroll event).
+ *
+ * Used to verify that scrollToRow is NOT called in synchronized map() — calling it would
+ * snap the vertical window to one row and evict all peers in the batch.
+ */
+function make2DVirtHtml(rowCount: number, windowSize = 5) {
+    return `<!DOCTYPE html><html>
+        <style>
+            .container { width: 300px; height: 200px; overflow: auto; position: relative; }
+            .viewport { width: 600px; height: ${rowCount * 30 + 30}px; position: relative; }
+            .grid { position: relative; width: 100%; }
+            .header-row { display: flex; position: sticky; top: 0; background: #eee; z-index: 10; height: 30px; }
+            .data-row { display: flex; position: absolute; height: 30px; width: 100%; }
+            .cell { width: 140px; padding: 4px; box-sizing: border-box; background: white; border-bottom: 1px solid #ddd; overflow: hidden; }
+            .col4 { left: 420px; position: absolute; }
+        </style>
+        <body>
+            <div class="container" id="scroller">
+                <div class="viewport">
+                    <div role="grid" class="grid" id="grid">
+                        <div class="header-row" role="row">
+                            <div role="columnheader" aria-colindex="1" class="cell">ID</div>
+                            <div role="columnheader" aria-colindex="2" class="cell">Name</div>
+                            <div role="columnheader" aria-colindex="3" class="cell">Email</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <script>
+                const ROW_COUNT = ${rowCount};
+                const WIN = ${windowSize};
+                const COUNTRIES = ['USA','Canada','UK','Germany','France','Japan','Brazil','Australia','India','Mexico'];
+                const scroller = document.getElementById('scroller');
+                const grid = document.getElementById('grid');
+
+                function renderRows() {
+                    // Remove old data rows
+                    grid.querySelectorAll('.data-row').forEach(r => r.remove());
+                    grid.querySelector('.col4-header')?.remove();
+
+                    const showCol4 = scroller.scrollLeft >= 150;
+                    const firstVisible = Math.floor(scroller.scrollTop / 30);
+                    const start = Math.max(0, firstVisible);
+                    const end = Math.min(ROW_COUNT - 1, start + WIN - 1);
+
+                    // Update col4 header
+                    const header = grid.querySelector('.header-row');
+                    if (showCol4 && !header.querySelector('[aria-colindex="4"]')) {
+                        const th = document.createElement('div');
+                        th.setAttribute('role','columnheader'); th.setAttribute('aria-colindex','4');
+                        th.className = 'cell col4 col4-header'; th.innerText = 'Country';
+                        header.appendChild(th);
+                    } else if (!showCol4) {
+                        header.querySelector('[aria-colindex="4"]')?.remove();
+                    }
+
+                    for (let i = start; i <= end; i++) {
+                        const row = document.createElement('div');
+                        row.className = 'data-row'; row.setAttribute('role','row');
+                        row.setAttribute('aria-rowindex', String(i + 2));
+                        row.style.top = (i * 30 + 30) + 'px';
+
+                        [[1,String(i+1)],[2,'Name-'+(i+1)],[3,'email'+(i+1)+'@test.com']].forEach(([ci, text]) => {
+                            const c = document.createElement('div');
+                            c.setAttribute('role','gridcell'); c.setAttribute('aria-colindex', String(ci));
+                            c.className = 'cell'; c.innerText = String(text); row.appendChild(c);
+                        });
+
+                        if (showCol4) {
+                            const c4 = document.createElement('div');
+                            c4.setAttribute('role','gridcell'); c4.setAttribute('aria-colindex','4');
+                            c4.className = 'cell col4'; c4.innerText = COUNTRIES[i % COUNTRIES.length];
+                            row.appendChild(c4);
+                        }
+                        grid.appendChild(row);
+                    }
+                }
+
+                scroller.addEventListener('scroll', renderRows);
+                renderRows(); // Initial render
+            </script>
+        </body></html>`;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Viewport strategy — synchronized map()', () => {
+    test('reads all columns across multiple rows using dataAttribute viewport', async ({ page }) => {
+        await page.setContent(makeHorizontalVirtHtml(4));
+        await page.waitForTimeout(200);
+
+        const COUNTRIES = ['USA', 'Canada', 'UK', 'Germany'];
+
+        const table = useTable(page.locator('[role="grid"]'), {
+            rowSelector: '.row[aria-rowindex]',
+            cellSelector: '[role="gridcell"]',
+            headerSelector: '[role="columnheader"]',
+            strategies: {
+                header: async ({ resolve, config, root, page: p }) => {
+                    const scroller = p.locator('#scroller');
+                    const headerLoc = resolve(config.headerSelector, root);
+                    const collected = new Set<string>();
+
+                    await scroller.evaluate((el: HTMLElement) => el.scrollLeft = 0);
+                    await p.waitForTimeout(100);
+                    let last = 0;
+                    for (let i = 0; i < 10; i++) {
+                        (await headerLoc.allInnerTexts()).forEach(t => collected.add(t.trim()));
+                        if (collected.size === last) break;
+                        last = collected.size;
+                        await scroller.evaluate((el: HTMLElement) => el.scrollLeft += 250);
+                        await p.waitForTimeout(100);
+                    }
+                    await scroller.evaluate((el: HTMLElement) => el.scrollLeft = 0);
+                    await p.waitForTimeout(100);
+                    return Array.from(collected);
+                },
+                getCellLocator: ({ row, columnIndex }) =>
+                    row.locator(`[aria-colindex="${columnIndex + 1}"]`),
+                viewport: Strategies.Viewport.dataAttribute({
+                    scrollContainer: '#scroller',
+                    rowAttribute: 'aria-rowindex',
+                    columnAttribute: 'aria-colindex',
+                    rowOffset: 2,
+                    columnOffset: 1,
+                    attachTimeout: 3000,
+                }),
+            },
+        });
+
+        await table.init();
+
+        // map() defaults to synchronized — all rows in the batch share one barrier
+        const results = await table.map(({ row }) => row.toJSON({ columns: ['ID', 'Name', 'Country'] }));
+
+        expect(results).toHaveLength(4);
+        results.forEach((r, i) => {
+            expect(r).toEqual({ ID: String(i + 1), Name: `Name-${i + 1}`, Country: COUNTRIES[i] });
+        });
+    });
+
+    test('does not call scrollToRow in synchronized mode when row appears out-of-range after col scroll', async ({ page }) => {
+        // 2D virtualized fixture: scrolling horizontally shifts which rows are in the DOM.
+        // Before fix: scrollToRow(rowIndex) was called inside the barrier, snapping the
+        // vertical window to one row and evicting all peers — causing timeouts for the rest.
+        // After fix: scrollToRow is skipped when barrier is active; all rows are read correctly.
+        await page.setContent(make2DVirtHtml(10, 5));
+        await page.waitForTimeout(200);
+
+        const table = useTable(page.locator('[role="grid"]'), {
+            rowSelector: '.data-row[aria-rowindex]',
+            cellSelector: '[role="gridcell"]',
+            headerSelector: '[role="columnheader"]',
+            strategies: {
+                header: async ({ resolve, config, root, page: p }) => {
+                    const scroller = p.locator('#scroller');
+                    const headerLoc = resolve(config.headerSelector, root);
+                    const collected = new Set<string>();
+                    await scroller.evaluate((el: HTMLElement) => el.scrollLeft = 0);
+                    await p.waitForTimeout(100);
+                    let last = 0;
+                    for (let i = 0; i < 10; i++) {
+                        (await headerLoc.allInnerTexts()).forEach(t => collected.add(t.trim()));
+                        if (collected.size === last) break;
+                        last = collected.size;
+                        await scroller.evaluate((el: HTMLElement) => el.scrollLeft += 200);
+                        await p.waitForTimeout(100);
+                    }
+                    await scroller.evaluate((el: HTMLElement) => el.scrollLeft = 0);
+                    await p.waitForTimeout(100);
+                    return Array.from(collected);
+                },
+                getCellLocator: ({ row, columnIndex }) =>
+                    row.locator(`[aria-colindex="${columnIndex + 1}"]`),
+                viewport: Strategies.Viewport.dataAttribute({
+                    scrollContainer: '#scroller',
+                    rowAttribute: 'aria-rowindex',
+                    columnAttribute: 'aria-colindex',
+                    rowOffset: 2,
+                    columnOffset: 1,
+                    attachTimeout: 4000,
+                }),
+                dedupe: async (row) => row.getAttribute('aria-rowindex'),
+            },
+            maxPages: 1,
+        });
+
+        await table.init();
+        const headers = await table.getHeaders();
+        expect(headers).toContain('Country');
+
+        // map() in synchronized mode — before fix, scrollToRow would evict peers
+        const results = await table.map(({ row }) => row.toJSON({ columns: ['ID', 'Country'] }), { maxPages: 1 });
+
+        expect(results.length).toBeGreaterThan(0);
+        results.forEach(r => {
+            expect(r.ID).toMatch(/^\d+$/);
+            expect(r.Country).toBeTruthy();
+        });
+    });
+});
+


### PR DESCRIPTION
## Problem

`scrollToRow` was being called inside the `scrollIntoViewport` barrier callback in synchronized/parallel mode. The barrier fires **once for the whole batch** (triggered by the last row to arrive), but `scrollToRow` snaps the viewport to **one specific row's position** — evicting every other row in that batch from the DOM. Those rows then fail to find their cells and time out.

## Fix

**`!barrier` guard on `scrollToRow`** — the scroll is only attempted when there is no barrier, i.e. in sequential mode where each row owns the viewport independently.

**`knownColRange` reuse** — the column range already fetched during the fast-path check (`getVisibleColumnRange`) was being re-queried inside `scrollIntoViewport`, adding an unnecessary DOM round-trip per cell. The result is now captured in `knownColRange` and reused; `scrollIntoViewport` only re-queries if the fast path didn't run.

## Tests

Added `tests/viewport-strategy.spec.ts` with two E2E tests that run entirely via `page.setContent` (no external server needed):

- **1D horizontal virt + synchronized `map()`** — 4-row table where column 4 mounts on scroll; verifies all cells are read correctly in one synchronized batch via the viewport strategy.
- **2D virt + synchronized `map()`** — both row and column visibility change on every scroll event; verifies the batch completes without eviction errors. This is the scenario where the old `scrollToRow` call was destructive.

> The sequential `scrollToRow` recovery path (the `!barrier` branch that's now properly isolated) is exercised by the existing `tests/integration/rdg.spec.ts` suite.

## Checklist
- [x] `pnpm run build` passes
- [x] `npx tsc --noEmit` clean
- [x] New tests pass (`npx playwright test tests/viewport-strategy.spec.ts`)
- [x] No `TODO`/`FIXME` in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart Table Inspector web UI and a paired MCP server (CLI/SSE) for table discovery, inspection, and config generation.
  * Automatic config generation from inspection results.
* **Bug Fixes**
  * Improved viewport navigation and horizontal-scroll recovery with parallel-navigation awareness.
* **Tests**
  * New unit and integration tests for detection heuristics and viewport strategies.
* **Documentation**
  * Site theme configuration updated (light/dark).
* **Chores**
  * Workspace/package manifests, startup script, and gitignore updates; new npm script to run the inspector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->