### PR TITLE
fix(iteration): remove NavigationBarrier from parallel mode

### DIFF
--- a/src/engine/tableIteration.ts
+++ b/src/engine/tableIteration.ts
@@ -49,7 +49,7 @@ export async function runMap<T, R>(
   const defaultMode = label === 'map' ? 'parallel' : 'sequential';
   const concurrency =
     options.concurrency ?? env.config.concurrency ?? defaultMode;
-  const useBarrier = concurrency !== 'sequential';
+  const useBarrier = concurrency === 'synchronized';
   // Mutex must not pair with the navigation barrier: synchronized mode needs every row
   // to enter barrier.sync concurrently; serializing callbacks here deadlocks (first row waits
   // for batchSize peers that never reach the barrier).


### PR DESCRIPTION
## Summary

- `parallel` mode previously received a `NavigationBarrier` (same as `synchronized`), making the two modes nearly identical in behavior
- Changed `useBarrier` from `concurrency !== 'sequential'` to `concurrency === 'synchronized'` so only `synchronized` gets the barrier
- `parallel` is now truly uncoordinated — no barrier, no mutex — giving it the best throughput for read-only operations where column scrolling is not needed
- `synchronized` retains the barrier for lock-step column scroll coordination on virtual/windowed tables
- `sequential` retains the mutex for strictly ordered, one-at-a-time row processing

## Test plan

- [x] `pnpm run build` passes (TypeScript + all code generators)
- [x] `pnpm run test:unit` passes (116/116 tests)
- [ ] E2E smoke: run a `parallel` map iteration against the playground and confirm it completes without deadlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected synchronization behavior for concurrent table iteration in synchronized mode to ensure proper row processing alignment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/141)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->