### PR TITLE
feat(iteration): expose pageIndex in RowIterationContext and async iterator

### DIFF
--- a/src/engine/tableIteration.ts
+++ b/src/engine/tableIteration.ts
@@ -123,7 +123,7 @@ export async function runMap<T, R>(
             const runCallback = async () => {
               if (stopped && row.rowIndex! > stoppedIndex) return SKIP;
               log(env.config, `${label}: processing row ${row.rowIndex}`);
-              return await callback({ row, index: row.rowIndex!, rowIndex: row.rowIndex!, stop: () => stop(row.rowIndex!) });
+              return await callback({ row, index: row.rowIndex!, rowIndex: row.rowIndex!, pageIndex: pagesScanned - 1, stop: () => stop(row.rowIndex!) });
             };
 
             if (actionMutex) {

--- a/src/engine/tableIteration.ts
+++ b/src/engine/tableIteration.ts
@@ -15,6 +15,7 @@ export interface TableIterationEnv<T = any> {
   createSmartRowArray: (rows: SmartRow<T>[]) => SmartRowArray<T>;
   config: FinalTableConfig<T>;
   getPage: () => Page;
+  getCurrentPageIndex: () => number;
 }
 
 function log(config: FinalTableConfig, msg: string) {
@@ -100,8 +101,8 @@ export async function runMap<T, R>(
         const barrier = useBarrier ? new NavigationBarrier(batchSize) : undefined;
         const actionMutex = useMutex ? new Mutex() : null;
         
-        const smartRows = newIndices.map((idx, i) => 
-          env.makeSmartRow(pageRows[idx], map, rowIndex + i, pagesScanned - 1, barrier)
+        const smartRows = newIndices.map((idx, i) =>
+          env.makeSmartRow(pageRows[idx], map, rowIndex + i, env.getCurrentPageIndex(), barrier)
         );
 
         const processRow = async (row: SmartRow<T>) => {
@@ -123,7 +124,7 @@ export async function runMap<T, R>(
             const runCallback = async () => {
               if (stopped && row.rowIndex! > stoppedIndex) return SKIP;
               log(env.config, `${label}: processing row ${row.rowIndex}`);
-              return await callback({ row, index: row.rowIndex!, rowIndex: row.rowIndex!, pageIndex: pagesScanned - 1, stop: () => stop(row.rowIndex!) });
+              return await callback({ row, index: row.rowIndex!, rowIndex: row.rowIndex!, pageIndex: env.getCurrentPageIndex(), stop: () => stop(row.rowIndex!) });
             };
 
             if (actionMutex) {

--- a/src/typeContext.ts
+++ b/src/typeContext.ts
@@ -556,6 +556,8 @@ export type RowIterationContext<T = any> = {
   rowIndex: number;
   /** 0-based iteration counter — the order this row was visited, not its DOM position or grid identity. */
   index: number;
+  /** 0-based page index — which page this row was collected from. */
+  pageIndex: number;
   stop: () => void;
 };
 
@@ -586,7 +588,7 @@ export type RowIterationOptions = {
   useBulkPagination?: boolean;
 };
 
-export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; rowIndex: number; index: number }> {
+export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; rowIndex: number; index: number; pageIndex: number }> {
   /**
    * Represents the current page index of the table's DOM.
    * Starts at 0. Automatically maintained by the library during pagination and bringIntoView.

--- a/src/types.ts
+++ b/src/types.ts
@@ -556,6 +556,8 @@ export type RowIterationContext<T = any> = {
   rowIndex: number;
   /** 0-based iteration counter — the order this row was visited, not its DOM position or grid identity. */
   index: number;
+  /** 0-based page index — which page this row was collected from. */
+  pageIndex: number;
   stop: () => void;
 };
 
@@ -586,7 +588,7 @@ export type RowIterationOptions = {
   useBulkPagination?: boolean;
 };
 
-export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; rowIndex: number; index: number }> {
+export interface TableResult<T = any> extends AsyncIterable<{ row: SmartRow<T>; rowIndex: number; index: number; pageIndex: number }> {
   /**
    * Represents the current page index of the table's DOM.
    * Starts at 0. Automatically maintained by the library during pagination and bringIntoView.

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -452,7 +452,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           const barrier = new NavigationBarrier(newIndices.length);
 
           for (const idx of newIndices) {
-            yield { row: _makeSmart(pageRows[idx], map, rowIndex, pagesScanned - 1, barrier), index: rowIndex, rowIndex, pageIndex: pagesScanned - 1 };
+            yield { row: _makeSmart(pageRows[idx], map, rowIndex, tableState.currentPageIndex, barrier), index: rowIndex, rowIndex, pageIndex: tableState.currentPageIndex };
             rowIndex++;
           }
 
@@ -479,6 +479,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           createSmartRowArray,
           config,
           getPage: () => rootLocator.page(),
+          getCurrentPageIndex: () => tableState.currentPageIndex,
         },
         callback,
         options
@@ -497,6 +498,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           createSmartRowArray,
           config,
           getPage: () => rootLocator.page(),
+          getCurrentPageIndex: () => tableState.currentPageIndex,
         },
         callback,
         options
@@ -515,6 +517,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           createSmartRowArray,
           config,
           getPage: () => rootLocator.page(),
+          getCurrentPageIndex: () => tableState.currentPageIndex,
         },
         predicate,
         options

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -434,7 +434,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
 
     // ─── Shared async row iterator ───────────────────────────────────────────
 
-    async *[Symbol.asyncIterator](): AsyncIterableIterator<{ row: SmartRowType<T>; index: number; rowIndex: number }> {
+    async *[Symbol.asyncIterator](): AsyncIterableIterator<{ row: SmartRowType<T>; index: number; rowIndex: number; pageIndex: number }> {
       await _autoInit();
       const map = tableMapper.getMapSync()!;
       const effectiveMaxPages = config.maxPages;
@@ -452,7 +452,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
           const barrier = new NavigationBarrier(newIndices.length);
 
           for (const idx of newIndices) {
-            yield { row: _makeSmart(pageRows[idx], map, rowIndex, pagesScanned - 1, barrier), index: rowIndex, rowIndex };
+            yield { row: _makeSmart(pageRows[idx], map, rowIndex, pagesScanned - 1, barrier), index: rowIndex, rowIndex, pageIndex: pagesScanned - 1 };
             rowIndex++;
           }
 

--- a/tests/unit/debugUtils.coverage.test.ts
+++ b/tests/unit/debugUtils.coverage.test.ts
@@ -126,6 +126,7 @@ function makeEnv(
     createSmartRowArray: (arr: any[]) => arr as any,
     config,
     getPage: () => ({ evaluate: async () => { } } as any),
+    getCurrentPageIndex: () => 0,
   };
 }
 

--- a/tests/unit/tableIteration.synchronized.test.ts
+++ b/tests/unit/tableIteration.synchronized.test.ts
@@ -60,6 +60,7 @@ function makeBarrierEnv(rowCount: number): TableIterationEnv<any> {
     createSmartRowArray: (arr: any[]) => arr as any,
     config,
     getPage: () => ({}) as any,
+    getCurrentPageIndex: () => 0,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `pageIndex` (0-based) to `RowIterationContext` — available in `forEach`, `map`, and `filter` callbacks
- Adds `pageIndex` to the async iterator yield (`for await (const { row, pageIndex } of table)`)
- `typeContext.ts` regenerated via `pnpm run build`

## Usage

```ts
let prevPageIndex = -1;

await table.forEach(({ row, index, pageIndex }) => {
  if (pageIndex !== prevPageIndex) {
    console.log(`Page ${pageIndex + 1}`);
    prevPageIndex = pageIndex;
  }
  // ...
});
```

## Test plan

- [x] `pnpm run build` passes
- [x] All 116 unit tests pass
- [x] `pageIndex` is 0-based, consistent with `index`
- [x] `typeContext.ts` regenerated

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Table iteration now includes pagination tracking: when iterating through rows, each row is tagged with its corresponding page number (0-based indexing), enabling better control and awareness of paginated data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->