### PR TITLE
feat(ci): upstream-blocker weekly check workflow and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/upstream-blocked.yml
+++ b/.github/ISSUE_TEMPLATE/upstream-blocked.yml
@@ -52,20 +52,26 @@ body:
         `blocked-pr` to wire up automatic detection.
 
         Supported `type` values: `npm` (checks `dist-tags.latest` on npm).
-        `condition` format: `latest <semver-range>` e.g. `latest >= 2.0.0`
+        `condition` format: `latest <semver-range>` e.g. `latest >= 2.0.0`.
+        The yaml block must be inside a `<details>` tag so it renders visibly
+        (collapsed by default) rather than being hidden as an HTML comment.
 
   - type: textarea
     id: upstream-check
     attributes:
       label: Upstream check block
-      description: Paste and fill in the block below exactly as shown — the workflow parses it as-is.
+      description: Paste and fill in the block below exactly as shown — the workflow parses the yaml code block inside the details tag.
       value: |
-        <!-- upstream-check
+        <details>
+        <summary>Automated upstream check</summary>
+
+        ```yaml
         type: npm
         package: <package-name>
         condition: latest >= <version>
         blocked-pr: <pr-number>
-        -->
+        ```
+        </details>
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/upstream-blocked.yml
+++ b/.github/ISSUE_TEMPLATE/upstream-blocked.yml
@@ -1,0 +1,78 @@
+name: Upstream Blocker
+description: Track work that is blocked on an upstream dependency or external release
+title: "chore: <summary> (blocked on <dependency>)"
+labels: ["upstream-blocker:waiting"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for work that can't proceed until an upstream dependency
+        ships a release. A weekly automated check will monitor the condition below
+        and swap the label to **upstream-blocker:cleared** once it is met.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is blocked and why?
+      placeholder: |
+        vitest 4.x requires vite >=6, but vitepress@1.x bundles vite@5 as a hard
+        dependency, causing a fatal peer conflict under pnpm strict resolution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-needs-to-happen
+    attributes:
+      label: What needs to happen
+      description: Ordered steps to unblock this work once the upstream condition is met.
+      placeholder: |
+        1. vitepress 2.0 stable ships
+        2. Merge the Dependabot PR for vitepress 2.0
+        3. Remove the vitest ignore rules in dependabot.yml
+    validations:
+      required: true
+
+  - type: input
+    id: blocked-pr
+    attributes:
+      label: Blocked PR (optional)
+      description: PR number that was closed or held because of this blocker.
+      placeholder: "116"
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Automated check configuration
+
+        The block below is parsed by the weekly upstream-blocker-check workflow.
+        **Do not remove it.** Fill in `package`, `condition`, and optionally
+        `blocked-pr` to wire up automatic detection.
+
+        Supported `type` values: `npm` (checks `dist-tags.latest` on npm).
+        `condition` format: `latest <semver-range>` e.g. `latest >= 2.0.0`
+
+  - type: textarea
+    id: upstream-check
+    attributes:
+      label: Upstream check block
+      description: Paste and fill in the block below exactly as shown — the workflow parses it as-is.
+      value: |
+        <!-- upstream-check
+        type: npm
+        package: <package-name>
+        condition: latest >= <version>
+        blocked-pr: <pr-number>
+        -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Relevant links (upstream issue tracker, changelog, release page).
+      placeholder: |
+        - https://github.com/vuejs/vitepress/releases

--- a/.github/workflows/upstream-blocker-check.yml
+++ b/.github/workflows/upstream-blocker-check.yml
@@ -1,0 +1,36 @@
+name: Upstream Blocker Check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check upstream blockers
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch issues with upstream-blocker:waiting
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue list \
+            --label "upstream-blocker:waiting" \
+            --json number,body,title \
+            --limit 100 \
+            > issues.json
+          echo "Issues found: $(node -e 'process.stdout.write(String(require("./issues.json").length))')"
+
+      - name: Run checks and update labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-upstream-blockers.mjs

--- a/.github/workflows/upstream-blocker-mutex.yml
+++ b/.github/workflows/upstream-blocker-mutex.yml
@@ -1,0 +1,30 @@
+name: Upstream Blocker Label Mutex
+
+# Keeps upstream-blocker:waiting and upstream-blocker:cleared mutually exclusive.
+# Applying either label automatically removes the other.
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  mutex:
+    name: Enforce label mutex
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Remove :waiting when :cleared is applied
+        if: github.event.label.name == 'upstream-blocker:cleared'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: gh issue edit $ISSUE --remove-label "upstream-blocker:waiting" || true
+
+      - name: Remove :cleared when :waiting is applied
+        if: github.event.label.name == 'upstream-blocker:waiting'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: gh issue edit $ISSUE --remove-label "upstream-blocker:cleared" || true

--- a/scripts/check-upstream-blockers.mjs
+++ b/scripts/check-upstream-blockers.mjs
@@ -15,9 +15,9 @@ console.log(`Found ${issues.length} issue(s) with upstream-blocker:waiting`);
 for (const { number, title, body } of issues) {
   console.log(`\n── Issue #${number}: ${title}`);
 
-  const blockMatch = body.match(/<!--\s*upstream-check\s*([\s\S]*?)-->/);
+  const blockMatch = body.match(/```yaml\s*([\s\S]*?)```/);
   if (!blockMatch) {
-    console.log('  No upstream-check block found — skipping');
+    console.log('  No upstream-check yaml block found — skipping');
     continue;
   }
 

--- a/scripts/check-upstream-blockers.mjs
+++ b/scripts/check-upstream-blockers.mjs
@@ -1,0 +1,85 @@
+/**
+ * Parses open issues labelled "upstream-blocker:waiting", runs each check,
+ * and swaps the label to "upstream-blocker:cleared" when the condition is met.
+ *
+ * Expects issues.json (written by the workflow) to contain the result of:
+ *   gh issue list --label "upstream-blocker:waiting" --json number,body,title
+ */
+
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+
+const issues = JSON.parse(readFileSync('issues.json', 'utf8'));
+console.log(`Found ${issues.length} issue(s) with upstream-blocker:waiting`);
+
+for (const { number, title, body } of issues) {
+  console.log(`\n── Issue #${number}: ${title}`);
+
+  const blockMatch = body.match(/<!--\s*upstream-check\s*([\s\S]*?)-->/);
+  if (!blockMatch) {
+    console.log('  No upstream-check block found — skipping');
+    continue;
+  }
+
+  const fields = Object.fromEntries(
+    blockMatch[1].trim().split('\n')
+      .map(line => line.split(':').map(s => s.trim()))
+      .filter(([k]) => k)
+      .map(([k, ...v]) => [k, v.join(':').trim()])
+  );
+
+  const { type, package: pkg, condition } = fields;
+  const blockedPr = fields['blocked-pr'];
+
+  if (type !== 'npm') {
+    console.log(`  Unsupported check type "${type}" — skipping`);
+    continue;
+  }
+  if (!pkg || !condition) {
+    console.log('  Missing package or condition — skipping');
+    continue;
+  }
+
+  let currentVersion;
+  try {
+    currentVersion = execSync(`npm view ${pkg} dist-tags.latest`, { encoding: 'utf8' }).trim();
+  } catch (e) {
+    console.error(`  Failed to fetch ${pkg} version: ${e.message}`);
+    continue;
+  }
+
+  console.log(`  ${pkg}@latest = ${currentVersion}`);
+
+  // condition format: "latest >= 2.0.0"
+  const range = condition.replace(/^latest\s*/, '');
+
+  let cleared = false;
+  try {
+    execSync(`npx --yes semver@7 "${currentVersion}" --range "${range}"`, { stdio: 'pipe' });
+    cleared = true;
+  } catch {
+    cleared = false;
+  }
+
+  if (!cleared) {
+    console.log(`  Still blocked — ${pkg}@${currentVersion} does not satisfy ${range}`);
+    continue;
+  }
+
+  console.log(`  CLEARED — ${pkg}@${currentVersion} satisfies ${range}`);
+
+  const lines = [
+    '## :green_circle: Upstream blocker cleared',
+    '',
+    `**${pkg}@${currentVersion}** is now available and satisfies \`${range}\`.`,
+  ];
+  if (blockedPr) {
+    lines.push('', `Next step: pick up #${blockedPr} to resume this work.`);
+  }
+  lines.push('', '_Posted automatically by the upstream blocker check workflow._');
+
+  writeFileSync('/tmp/upstream-comment.md', lines.join('\n'));
+  execSync(`gh issue comment ${number} --body-file /tmp/upstream-comment.md`);
+  execSync(`gh issue edit ${number} --remove-label "upstream-blocker:waiting" --add-label "upstream-blocker:cleared"`);
+  console.log('  Label swapped and comment posted.');
+}


### PR DESCRIPTION
## Summary

- **Weekly cron** (`upstream-blocker-check.yml`) runs every Monday at 09:00 UTC, finds all issues labelled `upstream-blocker:waiting`, parses each `<!-- upstream-check -->` block, and when the condition is met: swaps the label to `upstream-blocker:cleared` and posts a comment linking back to the blocked PR
- **Label mutex** (`upstream-blocker-mutex.yml`) listens for `issues.labeled` and keeps `:waiting` and `:cleared` mutually exclusive — applying one removes the other automatically
- **Issue template** (`upstream-blocked.yml`) provides a structured form with a pre-filled check block so new blocked issues are wired up correctly from the start
- **Check script** (`scripts/check-upstream-blockers.mjs`) handles `npm` dist-tag lookups with semver range evaluation via `npx semver`

## Labels created

| Label | Color | Meaning |
|---|---|---|
| `upstream-blocker:waiting` | 🟡 amber | Actively monitored; check runs weekly |
| `upstream-blocker:cleared` | 🟢 green | Condition met; ready to pick up |

## Issue template check block format

```
<!-- upstream-check
type: npm
package: vitepress
condition: latest >= 2.0.0
blocked-pr: 116
-->
```

## Test plan

- [ ] Trigger `upstream-blocker-check` manually via `workflow_dispatch` — should log "Still blocked" for issue #118 while vitepress is still on 1.x
- [ ] Apply `upstream-blocker:cleared` to any issue — confirm `upstream-blocker:waiting` is removed by the mutex workflow
- [ ] Apply `upstream-blocker:waiting` to any issue — confirm `upstream-blocker:cleared` is removed

Note: issue #118 still needs its label swapped from `blocked:upstream` → `upstream-blocker:waiting` and the check block added to its body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)