### PR TITLE
fix(ci): run Dependabot checks when human updates the branch

### DIFF
--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   age-check:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.triggering_actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Verify npm packages are ≥ 7 days old
         uses: actions/github-script@v9
@@ -29,8 +29,10 @@ jobs:
             const updateRegex = /Updates\s+`([^`]+)`\s+from\s+[\d][^\s]*\s+to\s+([\d][^\s]*)/ig;
             let m;
             const tooYoung = [];
+            let matchFound = false;
 
             while ((m = updateRegex.exec(body)) !== null) {
+              matchFound = true;
               const pkg = m[1];
               const version = m[2];
               const encoded = pkg.startsWith('@') ? pkg.replace('/', '%2F') : pkg;
@@ -62,6 +64,11 @@ jobs:
               } else {
                 core.info(`✓ ${pkg}@${version} is ${ageDays} days old`);
               }
+            }
+
+            if (!matchFound) {
+              core.setFailed('No package updates found in PR body — Dependabot format may have changed');
+              return;
             }
 
             if (tooYoung.length > 0) {

--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   age-check:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || github.triggering_actor == 'dependabot[bot]'
     steps:
       - name: Verify npm packages are ≥ 7 days old
         uses: actions/github-script@v9

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   enable-automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' || github.triggering_actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write
@@ -28,12 +28,17 @@ jobs:
             const body = pr.data.body || '';
             const regex = /from\s+([0-9]+)\.([0-9]+)\.([0-9]+)[^\n]*to\s+([0-9]+)\.([0-9]+)\.([0-9]+)/ig;
             let m;
+            let foundMatch = false;
             while ((m = regex.exec(body)) !== null) {
+              foundMatch = true;
               const fromMajor = parseInt(m[1], 10);
               const toMajor = parseInt(m[4], 10);
               if (toMajor > fromMajor) {
                 core.setFailed(`Contains a major version bump: ${m[0]}`);
               }
+            }
+            if (!foundMatch) {
+              core.setFailed('No version bump patterns found in PR body — Dependabot format may have changed');
             }
 
       - name: Enable auto-merge for Dependabot PR (squash)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   enable-automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' || github.triggering_actor == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Fixes both `dependabot-auto-merge` and `dependabot-age-check` workflows skipping when a human rebases/updates a Dependabot PR
- `github.actor` is set to the human who triggered the `synchronize` event, so the `if: github.actor == 'dependabot[bot]'` guard was skipping the whole job
- Added `|| github.triggering_actor == 'dependabot[bot]'` so checks run regardless of who pushes to the branch

Followup to #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Dependabot PR validation to ensure updated packages meet a 7-day age threshold before auto-merge approval.
  * Improved conditional logic in the dependency update workflow for more reliable automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->