### PR TITLE
feat(ci): post rebase-after comment when age check fails

### DIFF
--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -11,6 +11,8 @@ jobs:
   age-check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
     steps:
       - name: Verify npm packages are ≥ 7 days old
         uses: actions/github-script@v9
@@ -30,6 +32,7 @@ jobs:
             let m;
             const tooYoung = [];
             let matchFound = false;
+            let latestPublish = 0;
 
             while ((m = updateRegex.exec(body)) !== null) {
               matchFound = true;
@@ -57,7 +60,10 @@ jobs:
                 return;
               }
 
-              const ageMs = now - new Date(publishedAt).getTime();
+              const publishedMs = new Date(publishedAt).getTime();
+              if (publishedMs > latestPublish) latestPublish = publishedMs;
+
+              const ageMs = now - publishedMs;
               const ageDays = (ageMs / (24 * 60 * 60 * 1000)).toFixed(1);
               if (ageMs < MIN_AGE_MS) {
                 tooYoung.push(`${pkg}@${version} (published ${ageDays} days ago)`);
@@ -72,8 +78,24 @@ jobs:
             }
 
             if (tooYoung.length > 0) {
+              const rebaseAfter = new Date(latestPublish + MIN_AGE_MS);
+              const rebaseAfterISO = rebaseAfter.toISOString().slice(0, 10);
+
+              // Post a comment with a machine-readable marker so a future cron job
+              // can find PRs that are ready to rebase and post "@dependabot rebase".
+              // Format: <!-- age-check-rebase-after: YYYY-MM-DD -->
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `<!-- age-check-rebase-after: ${rebaseAfterISO} -->\n` +
+                  `⏳ **npm soak period active** — one or more packages are less than 7 days old.\n\n` +
+                  tooYoung.map(p => `- ${p}`).join('\n') + '\n\n' +
+                  `Safe to rebase on **${rebaseAfterISO}**. Run \`@dependabot rebase\` then.`,
+              });
+
               core.setFailed(
-                `The following packages are less than 7 days old on npm — waiting for the soak period:\n` +
+                `The following packages are less than 7 days old on npm — safe to rebase on ${rebaseAfterISO}:\n` +
                 tooYoung.map(p => `  • ${p}`).join('\n')
               );
             }

--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -91,7 +91,7 @@ jobs:
                 body: `<!-- age-check-rebase-after: ${rebaseAfterISO} -->\n` +
                   `⏳ **npm soak period active** — one or more packages are less than 7 days old.\n\n` +
                   tooYoung.map(p => `- ${p}`).join('\n') + '\n\n' +
-                  `Safe to rebase on **${rebaseAfterISO}**. Run \`@dependabot rebase\` then.`,
+                  `Safe to merge after **${rebaseAfterISO}**. Trigger a Dependabot rebase then.`,
               });
 
               core.setFailed(

--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -32,6 +32,7 @@ jobs:
             let m;
             const tooYoung = [];
             let matchFound = false;
+            let npmPackageFound = false;
             let latestPublish = 0;
 
             while ((m = updateRegex.exec(body)) !== null) {
@@ -44,6 +45,10 @@ jobs:
               let data;
               try {
                 const response = await fetch(url);
+                if (response.status === 404) {
+                  core.info(`${pkg} not found on npm — skipping (likely a GitHub Actions dependency)`);
+                  continue;
+                }
                 if (!response.ok) {
                   core.setFailed(`Failed to fetch npm metadata for ${pkg}: HTTP ${response.status}`);
                   return;
@@ -54,6 +59,7 @@ jobs:
                 return;
               }
 
+              npmPackageFound = true;
               const publishedAt = data.time?.[version];
               if (!publishedAt) {
                 core.setFailed(`No publish timestamp found for ${pkg}@${version} on npm`);
@@ -74,6 +80,10 @@ jobs:
 
             if (!matchFound) {
               core.setFailed('No package updates found in PR body — Dependabot format may have changed');
+              return;
+            }
+            if (!npmPackageFound) {
+              core.info('No npm packages found — skipping age check (GitHub Actions dependencies only)');
               return;
             }
 

--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -91,18 +91,36 @@ jobs:
               const rebaseAfter = new Date(latestPublish + MIN_AGE_MS);
               const rebaseAfterISO = rebaseAfter.toISOString().slice(0, 10);
 
-              // Post a comment with a machine-readable marker so a future cron job
+              // Upsert a comment with a machine-readable marker so a future cron job
               // can find PRs that are ready to rebase and post "@dependabot rebase".
               // Format: <!-- age-check-rebase-after: YYYY-MM-DD -->
-              await github.rest.issues.createComment({
+              const MARKER = '<!-- age-check-rebase-after:';
+              const commentBody = `<!-- age-check-rebase-after: ${rebaseAfterISO} -->\n` +
+                `⏳ **npm soak period active** — one or more packages are less than 7 days old.\n\n` +
+                tooYoung.map(p => `- ${p}`).join('\n') + '\n\n' +
+                `Safe to merge after **${rebaseAfterISO}**. Trigger a Dependabot rebase then.`;
+
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `<!-- age-check-rebase-after: ${rebaseAfterISO} -->\n` +
-                  `⏳ **npm soak period active** — one or more packages are less than 7 days old.\n\n` +
-                  tooYoung.map(p => `- ${p}`).join('\n') + '\n\n' +
-                  `Safe to merge after **${rebaseAfterISO}**. Trigger a Dependabot rebase then.`,
               });
+              const existing = comments.find(c => c.body?.includes(MARKER));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: commentBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: commentBody,
+                });
+              }
 
               core.setFailed(
                 `The following packages are less than 7 days old on npm — safe to rebase on ${rebaseAfterISO}:\n` +


### PR DESCRIPTION
## Summary

When packages fail the 7-day soak check, the workflow now posts a PR comment with:
- A machine-readable marker: `<!-- age-check-rebase-after: YYYY-MM-DD -->`
- A human-readable list of too-young packages and the exact safe rebase date

## Future cron job

The marker is designed so a scheduled workflow can do:
1. List open Dependabot PRs
2. Search their comments for `<!-- age-check-rebase-after: YYYY-MM-DD -->`
3. If today ≥ that date, post `@dependabot rebase`

## Changes
- Added `pull-requests: write` permission to the `age-check` job
- Tracks `latestPublish` across all packages to compute the correct rebase date (latest publish + 7 days)
- Posts comment and includes the date in the `setFailed` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened dependency update verification process to enforce a stability soak period, ensuring new packages meet quality standards before integration into releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/152)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->