### PR TITLE
fix(table): countRows paginates across all pages and resets afterward

### DIFF
--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -288,7 +288,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
     countRows: async (): Promise<number> => {
       await _autoInit();
       const pag = config.strategies.pagination;
-      const hasPagination = config.maxPages > 1 && !!(pag?.goNext || pag?.goNextBulk || pag?.goToPage);
+      const hasPagination = config.maxPages > 1 && !!(pag?.goNext || pag?.goNextBulk);
       if (!hasPagination) {
         log("countRows: counting rows in current viewport (no pagination)");
         return resolve(config.rowSelector, rootLocator).count();

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -286,10 +286,32 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
     },
 
     countRows: async (): Promise<number> => {
-      log("countRows: counting rows in current viewport");
       await _autoInit();
-      const allRows = resolve(config.rowSelector, rootLocator);
-      return allRows.count();
+      const hasPagination = !!config.strategies.pagination && config.maxPages > 1;
+      if (!hasPagination) {
+        log("countRows: counting rows in current viewport (no pagination)");
+        return resolve(config.rowSelector, rootLocator).count();
+      }
+
+      log(`countRows: paginating up to ${config.maxPages} page(s)`);
+      const tracker = new ElementTracker('countRows');
+      let total = 0;
+      let pagesScanned = 1;
+      try {
+        while (true) {
+          const newIndices = await tracker.getUnseenIndices(resolve(config.rowSelector, rootLocator));
+          total += newIndices.length;
+          log(`countRows: page ${pagesScanned} — ${newIndices.length} row(s) (running total: ${total})`);
+          if (pagesScanned >= config.maxPages) break;
+          if (!await _advancePage(false)) break;
+          pagesScanned++;
+        }
+      } finally {
+        await tracker.cleanup(rootLocator.page());
+      }
+      log(`countRows: ${total} total row(s) across ${pagesScanned} page(s) — resetting`);
+      await result.reset();
+      return total;
     },
 
     mapColumn: async <R = string>(columnName: string, options: import('./types').RowIterationOptions = {}): Promise<R[]> => {

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -287,7 +287,8 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
 
     countRows: async (): Promise<number> => {
       await _autoInit();
-      const hasPagination = !!config.strategies.pagination && config.maxPages > 1;
+      const pag = config.strategies.pagination;
+      const hasPagination = config.maxPages > 1 && !!(pag?.goNext || pag?.goNextBulk || pag?.goToPage);
       if (!hasPagination) {
         log("countRows: counting rows in current viewport (no pagination)");
         return resolve(config.rowSelector, rootLocator).count();

--- a/tests/functional-methods.spec.ts
+++ b/tests/functional-methods.spec.ts
@@ -445,6 +445,13 @@ test.describe('new API additions', () => {
         expect(await table.countRows()).toBe(2);
     });
 
+    test('countRows returns current page count when maxPages > 1 but no pagination primitive', async ({ page }) => {
+        await page.setContent(TABLE_HTML);
+        const table = useTable(page.locator('#tbl'), { maxPages: 3 });
+
+        expect(await table.countRows()).toBe(2);
+    });
+
     test('mapColumn collects values for a single column', async ({ page }) => {
         await page.setContent(TABLE_HTML);
         const table = makeTable(page);

--- a/tests/functional-methods.spec.ts
+++ b/tests/functional-methods.spec.ts
@@ -17,6 +17,7 @@ const TABLE_HTML = `
     <tbody id="tbody"></tbody>
   </table>
   <button id="next">Next</button>
+  <button id="first">First</button>
   <script>
     const pages = [
       [['1','Alice','Active'],['2','Bob','Inactive']],
@@ -33,6 +34,9 @@ const TABLE_HTML = `
     }
     document.getElementById('next').addEventListener('click', () => {
       if (currentPage < pages.length - 1) { currentPage++; render(); }
+    });
+    document.getElementById('first').addEventListener('click', () => {
+      currentPage = 0; render();
     });
     render();
   </script>
@@ -417,10 +421,27 @@ test.describe('numeric pagination result in useTable iteration', () => {
 
 // ─── new API additions (#89, #84, #43, #82) ───────────────────────────────────
 test.describe('new API additions', () => {
-    test('countRows counts the rows on current page', async ({ page }) => {
+    test('countRows paginates and returns total row count across all pages', async ({ page }) => {
         await page.setContent(TABLE_HTML);
-        const table = makeTable(page);
-        
+        const table = useTable(page.locator('#tbl'), {
+            maxPages: 3,
+            strategies: {
+                pagination: Strategies.Pagination.click({
+                    next: () => page.locator('#next'),
+                    first: () => page.locator('#first'),
+                }),
+            },
+        });
+
+        expect(await table.countRows()).toBe(6);
+        // reset() via goToFirst should have returned us to page 1
+        expect(await page.locator('#current-page').innerText()).toBe('1');
+    });
+
+    test('countRows returns current page count when no pagination configured', async ({ page }) => {
+        await page.setContent(TABLE_HTML);
+        const table = useTable(page.locator('#tbl'), {});
+
         expect(await table.countRows()).toBe(2);
     });
 


### PR DESCRIPTION
## Summary

- `countRows` previously called `allRows.count()` on the current DOM viewport only — callers with `maxPages > 1` would get the row count of whichever page the table was last on, not a total
- Now paginates through all pages (up to `config.maxPages`) using `ElementTracker` for deduplication, then calls `reset()` to return to page 1
- Single-page behavior (no pagination strategy configured, or `maxPages <= 1`) is unchanged — still a fast synchronous-style count with no navigation

## Test plan

- [x] `countRows paginates and returns total row count across all pages` — verifies count is 6 (3 pages × 2 rows) and `reset()` navigates back to page 1
- [x] `countRows returns current page count when no pagination configured` — verifies existing single-page behavior unchanged
- [x] All 116 unit tests pass
- [x] `pnpm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Row counting now aggregates totals across pages when pagination is enabled and navigation controls are available.
* **Bug Fixes**
  * When pagination is not configured or navigation controls are absent, counting correctly reports only the current page.
* **Tests**
  * Updated fixtures and tests to verify total-count behavior and that the UI returns to page one after a pagination-aware count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->