### PR TITLE
chore(coderabbit): run on Dependabot PRs, suppress lockfile comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,8 +3,8 @@
 
 reviews:
   auto_review:
-    # Skip automatic review on draft PRs and Dependabot PRs.
-    # Trigger manually with `@coderabbitai review` when ready.
     drafts: false
-    ignore_usernames:
-      - "dependabot[bot]"
+  path_filters:
+    - "!pnpm-lock.yaml"
+    - "!package-lock.json"
+    - "!package.json"


### PR DESCRIPTION
## Summary

- Removes `ignore_usernames: dependabot[bot]` — CodeRabbit was silently skipping Dependabot PRs, which left the required check status in a permanent pending state and blocked auto-merge
- Adds `path_filters` to suppress review comments on `pnpm-lock.yaml`, `package-lock.json`, and `package.json` — keeps lockfile noise out of reviews while still running the check and posting a status

## Test plan

- [ ] Merge this PR
- [ ] Trigger a Dependabot PR and confirm CodeRabbit posts a check status (approved/commented) rather than staying pending
- [ ] Confirm review comments are not generated for lockfile-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review configuration to refine the review process, excluding package lock files from automatic review while adjusting dependency-related pull request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->