### PR TITLE
chore(husky): add pre-push rebase check against origin/main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,8 +4,17 @@
 
 git fetch origin main --quiet 2>/dev/null || exit 0
 
-main=$(git rev-parse origin/main)
-base=$(git merge-base HEAD "$main")
+main=$(git rev-parse origin/main 2>/dev/null)
+if [ -z "$main" ]; then
+  echo "✗ pre-push: could not resolve origin/main — skipping rebase check."
+  exit 1
+fi
+
+base=$(git merge-base HEAD "$main" 2>/dev/null)
+if [ -z "$base" ]; then
+  echo "✗ pre-push: could not compute merge-base with origin/main — skipping rebase check."
+  exit 1
+fi
 
 if [ "$base" != "$main" ]; then
   echo "✗ Branch is not rebased onto origin/main."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Verify the branch is rebased onto origin/main before pushing.
+# Fetches origin/main first; if offline, skips the check silently.
+
+git fetch origin main --quiet 2>/dev/null || exit 0
+
+main=$(git rev-parse origin/main)
+base=$(git merge-base HEAD "$main")
+
+if [ "$base" != "$main" ]; then
+  echo "✗ Branch is not rebased onto origin/main."
+  echo "  Run: git fetch origin && git rebase origin/main"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `.husky/pre-push` that fetches `origin/main` and verifies the current branch is rebased onto it before every push
- If offline, the fetch fails silently (`|| exit 0`) and the push proceeds — no blocking in air-gap scenarios
- Fails with a clear, actionable message if rebasing has been skipped

## Why

The rebase-before-push rule was documented in CLAUDE.md and stored in agent memory, but memory doesn't survive conversation boundaries reliably. A hook makes it impossible to forget — the push simply fails if the step was skipped.

## Test plan

- [ ] Push a branch that hasn't been rebased — confirm hook exits 1 with the error message
- [ ] Push a rebased branch — confirm hook exits 0
- [ ] Disconnect from the network and push — confirm hook exits 0 silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a pre-push validation to ensure commits are properly rebased on the main branch before pushing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->