### PR TITLE
fix(debug): Group A — wire debug.slow.pagination + improve verbose log coverage

### DIFF
--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -23,10 +23,6 @@ export class RowFinder<T = any> {
         this.resolve = resolve;
     }
 
-    private log(msg: string) {
-        logDebug(this.config, 'verbose', msg);
-    }
-
     public async findRow(
         filters: Record<string, FilterValue>,
         options: { exact?: boolean, maxPages?: number } = {}
@@ -65,7 +61,7 @@ export class RowFinder<T = any> {
         const effectiveMaxPages = options?.maxPages ?? this.config.maxPages ?? Infinity;
         let pagesScanned = 1;
 
-        this.log(`findRows: starting (maxPages=${effectiveMaxPages}, filters=${JSON.stringify(filtersRecord)})`);
+        logDebug(this.config, 'verbose',`findRows: starting (maxPages=${effectiveMaxPages}, filters=${JSON.stringify(filtersRecord)})`);
 
         const tracker = new ElementTracker('findRows');
 
@@ -93,13 +89,13 @@ export class RowFinder<T = any> {
                 for (const idx of newIndices) {
                     const smartRow = this.makeSmartRow(currentRows[idx], map, allRows.length, this.tableState.currentPageIndex);
                     if (isRowLoading && await isRowLoading(smartRow)) {
-                        this.log(`findRows: page ${this.tableState.currentPageIndex} — row skipped (isRowLoading=true)`);
+                        logDebug(this.config, 'verbose',`findRows: page ${this.tableState.currentPageIndex} — row skipped (isRowLoading=true)`);
                         continue;
                     }
                     allRows.push(smartRow);
                     added++;
                 }
-                this.log(`findRows: page ${this.tableState.currentPageIndex} — ${added} new match(es) (total: ${allRows.length})`);
+                logDebug(this.config, 'verbose',`findRows: page ${this.tableState.currentPageIndex} — ${added} new match(es) (total: ${allRows.length})`);
             };
 
             // Scan first page
@@ -121,20 +117,20 @@ export class RowFinder<T = any> {
                 } else if (this.config.strategies.pagination?.goNext) {
                     paginationResult = await this.config.strategies.pagination.goNext(context);
                 } else {
-                    this.log(`findRows: no pagination primitive — stopping`);
+                    logDebug(this.config, 'verbose',`findRows: no pagination primitive — stopping`);
                     break;
                 }
 
                 const didPaginate = validatePaginationResult(paginationResult, 'Pagination Strategy');
                 if (!didPaginate) {
-                    this.log(`findRows: pagination returned false — end of data`);
+                    logDebug(this.config, 'verbose',`findRows: pagination returned false — end of data`);
                     break;
                 }
 
                 const pagesJumped = typeof paginationResult === 'number' ? paginationResult : 1;
                 this.tableState.currentPageIndex += pagesJumped;
                 pagesScanned += pagesJumped;
-                this.log(`findRows: advanced ${pagesJumped} page(s), now at page ${this.tableState.currentPageIndex}`);
+                logDebug(this.config, 'verbose',`findRows: advanced ${pagesJumped} page(s), now at page ${this.tableState.currentPageIndex}`);
                 await debugDelay(this.config, 'pagination');
                 await collectMatches();
             }
@@ -142,7 +138,7 @@ export class RowFinder<T = any> {
             await tracker.cleanup(this.rootLocator.page());
         }
 
-        this.log(`findRows: done — ${allRows.length} row(s) collected across ${pagesScanned} page(s)`);
+        logDebug(this.config, 'verbose',`findRows: done — ${allRows.length} row(s) collected across ${pagesScanned} page(s)`);
         return createSmartRowArray(allRows);
     }
 
@@ -154,7 +150,7 @@ export class RowFinder<T = any> {
         const effectiveMaxPages = options.maxPages ?? this.config.maxPages;
         let pagesScanned = 1;
 
-        this.log(`Looking for row: ${JSON.stringify(filters)} (MaxPages: ${effectiveMaxPages})`);
+        logDebug(this.config, 'verbose',`Looking for row: ${JSON.stringify(filters)} (MaxPages: ${effectiveMaxPages})`);
 
         while (true) {
             // Check Loading
@@ -167,7 +163,7 @@ export class RowFinder<T = any> {
                 });
 
                 if (isLoading) {
-                    this.log('Table is loading... waiting');
+                    logDebug(this.config, 'verbose','Table is loading... waiting');
                     await this.rootLocator.page().waitForTimeout(200);
                     continue;
                 }
@@ -184,7 +180,7 @@ export class RowFinder<T = any> {
             );
 
             const count = await matchedRows.count();
-            this.log(`Page ${this.tableState.currentPageIndex}: Found ${count} matches.`);
+            logDebug(this.config, 'verbose',`Page ${this.tableState.currentPageIndex}: Found ${count} matches.`);
 
             if (count > 1) {
                 const sampleData: string[] = [];
@@ -207,7 +203,7 @@ export class RowFinder<T = any> {
             if (count === 1) return matchedRows.first();
 
             if (pagesScanned < effectiveMaxPages) {
-                this.log(`Page ${this.tableState.currentPageIndex}: Not found. Attempting pagination...`);
+                logDebug(this.config, 'verbose',`Page ${this.tableState.currentPageIndex}: Not found. Attempting pagination...`);
                 const context: TableContext = {
                     root: this.rootLocator,
                     config: this.config,
@@ -223,7 +219,7 @@ export class RowFinder<T = any> {
                 } else if (pagination?.goNext) {
                     paginationResult = await pagination.goNext(context);
                 } else {
-                    this.log(`Page ${this.tableState.currentPageIndex}: Pagination failed (no goNext or goNextBulk primitive).`);
+                    logDebug(this.config, 'verbose',`Page ${this.tableState.currentPageIndex}: Pagination failed (no goNext or goNextBulk primitive).`);
                     return null;
                 }
 
@@ -236,7 +232,7 @@ export class RowFinder<T = any> {
                     await debugDelay(this.config, 'pagination');
                     continue;
                 } else {
-                    this.log(`Page ${this.tableState.currentPageIndex}: Pagination failed (end of data).`);
+                    logDebug(this.config, 'verbose',`Page ${this.tableState.currentPageIndex}: Pagination failed (end of data).`);
                 }
             }
             return null;

--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -135,6 +135,7 @@ export class RowFinder<T = any> {
                 this.tableState.currentPageIndex += pagesJumped;
                 pagesScanned += pagesJumped;
                 this.log(`findRows: advanced ${pagesJumped} page(s), now at page ${this.tableState.currentPageIndex}`);
+                await debugDelay(this.config, 'pagination');
                 await collectMatches();
             }
         } finally {
@@ -232,6 +233,7 @@ export class RowFinder<T = any> {
                     const pagesJumped = typeof paginationResult === 'number' ? paginationResult : 1;
                     this.tableState.currentPageIndex += pagesJumped;
                     pagesScanned += pagesJumped;
+                    await debugDelay(this.config, 'pagination');
                     continue;
                 } else {
                     this.log(`Page ${this.tableState.currentPageIndex}: Pagination failed (end of data).`);

--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -229,6 +229,7 @@ export class RowFinder<T = any> {
                     const pagesJumped = typeof paginationResult === 'number' ? paginationResult : 1;
                     this.tableState.currentPageIndex += pagesJumped;
                     pagesScanned += pagesJumped;
+                    logDebug(this.config, 'verbose', `findRowLocator: advanced ${pagesJumped} page(s), now at page ${this.tableState.currentPageIndex}`);
                     await debugDelay(this.config, 'pagination');
                     continue;
                 } else {

--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -218,6 +218,7 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
     if (pagesJumped > 0) {
       tableState.currentPageIndex += pagesJumped;
       log(`_advancePage: ${primitive} advanced ${pagesJumped} page(s) — now at page ${tableState.currentPageIndex}`);
+      await debugDelay(config, 'pagination');
     } else {
       log(`_advancePage: ${primitive} returned false — end of data`);
     }
@@ -463,6 +464,8 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
       const effectiveMaxPages = config.maxPages;
       const tracker = new ElementTracker('iterator');
       const useBulk = false; // iterator has no options; default goNext
+
+      log(`iterator: starting (maxPages=${effectiveMaxPages})`);
 
       try {
         let rowIndex = 0;

--- a/tests/unit/debugUtils.coverage.test.ts
+++ b/tests/unit/debugUtils.coverage.test.ts
@@ -255,7 +255,8 @@ function makeRowFinder(config: FinalTableConfig, paginationPages = 1) {
     (_item: any, parent: any) => parent,
     filterEngine,
     tableMapper,
-    makeSmartRow
+    makeSmartRow,
+    { currentPageIndex: 0 }
   );
 }
 

--- a/tests/unit/debugUtils.coverage.test.ts
+++ b/tests/unit/debugUtils.coverage.test.ts
@@ -207,3 +207,95 @@ describe('Iteration engine verbose logging', () => {
     expect(loggedMessages.some(m => m.includes('dedupe skip'))).toBe(true);
   });
 });
+
+// ─── RowFinder verbose logging tests ─────────────────────────────────────────
+
+import { RowFinder } from '../../src/engine/rowFinder';
+
+function makeRowFinder(config: FinalTableConfig, paginationPages = 1) {
+  let pagesAdvanced = 0;
+  const fakeRows: any[] = [];
+
+  const makeLocator = (): any => ({
+    all: async () => fakeRows,
+    count: async () => fakeRows.length,
+    filter: () => makeLocator(),
+    first: () => fakeRows[0],
+    page: () => ({ waitForTimeout: async () => {} }),
+  });
+
+  const rootLocator: any = {
+    ...makeLocator(),
+    page: () => ({ waitForTimeout: async () => {} }),
+  };
+
+  const filterEngine: any = {
+    applyFilters: () => ({ count: async () => 0, all: async () => [], first: () => null }),
+  };
+
+  const tableMapper: any = {
+    getMap: async () => new Map([['Name', 0]]),
+  };
+
+  const paginationStrategy = paginationPages > 1
+    ? { goNext: async () => { pagesAdvanced++; return pagesAdvanced < paginationPages; } }
+    : undefined;
+
+  const cfgWithPagination: FinalTableConfig = {
+    ...config,
+    strategies: { ...config.strategies, pagination: paginationStrategy },
+  } as any;
+
+  const makeSmartRow = (_loc: any, _map: any, idx: number) =>
+    ({ rowIndex: idx, getCell: () => ({}), toJSON: async () => ({}) } as any);
+
+  return new RowFinder(
+    rootLocator,
+    cfgWithPagination,
+    (_item: any, parent: any) => parent,
+    filterEngine,
+    tableMapper,
+    makeSmartRow
+  );
+}
+
+describe('RowFinder verbose logging', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let loggedMessages: string[];
+
+  beforeEach(() => {
+    loggedMessages = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation((...args: any[]) => {
+      loggedMessages.push(args.join(' '));
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('findRows emits "findRows: starting" under verbose', async () => {
+    const config = makeVerboseConfig();
+    await makeRowFinder(config).findRows({});
+    expect(loggedMessages.some(m => m.includes('findRows: starting'))).toBe(true);
+  });
+
+  it('findRows emits "findRows: done" under verbose', async () => {
+    const config = makeVerboseConfig();
+    await makeRowFinder(config).findRows({});
+    expect(loggedMessages.some(m => m.includes('findRows: done'))).toBe(true);
+  });
+
+  it('findRow emits "Searching for row" at info level', async () => {
+    const config = makeVerboseConfig({ debug: { logLevel: 'info' } } as any);
+    await makeRowFinder(config).findRow({});
+    expect(loggedMessages.some(m => m.includes('Searching for row'))).toBe(true);
+  });
+
+  it('findRows suppresses verbose logs when logLevel is "none"', async () => {
+    const config = makeVerboseConfig({ debug: { logLevel: 'none' } } as any);
+    await makeRowFinder(config).findRows({});
+    const smartTableLogs = loggedMessages.filter(m => m.includes('[SmartTable]'));
+    expect(smartTableLogs.length).toBe(0);
+  });
+});

--- a/tests/unit/rowFinder.pagination.delay.test.ts
+++ b/tests/unit/rowFinder.pagination.delay.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Verifies that debugDelay is called with the 'pagination' action type after
+ * each successful page advance in RowFinder.findRows and findRowLocator (via
+ * findRow). Kept in its own file so we can mock debugUtils without affecting
+ * tests that exercise the real debugDelay implementation.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/utils/elementTracker', () => ({
+  ElementTracker: class {
+    private _called = false;
+    async getUnseenIndices(locators: any) {
+      if (this._called) return [];
+      const rows = await locators.all();
+      this._called = true;
+      return rows.map((_: any, i: number) => i);
+    }
+    async cleanup() {}
+  },
+}));
+
+vi.mock('../../src/utils/debugUtils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/utils/debugUtils')>();
+  return { ...actual, debugDelay: vi.fn().mockResolvedValue(undefined) };
+});
+
+import { RowFinder } from '../../src/engine/rowFinder';
+import * as debugUtils from '../../src/utils/debugUtils';
+import type { FinalTableConfig } from '../../src/types';
+
+const debugDelaySpy = debugUtils.debugDelay as ReturnType<typeof vi.fn>;
+
+function makeConfig(overrides: Partial<FinalTableConfig> = {}): FinalTableConfig {
+  return {
+    rowSelector: 'tr',
+    headerSelector: 'th',
+    cellSelector: 'td',
+    maxPages: 3,
+    autoScroll: false,
+    headerTransformer: ({ text }: any) => text,
+    onReset: async () => {},
+    strategies: {},
+    ...overrides,
+  } as any;
+}
+
+function makeRowFinder(config: FinalTableConfig) {
+  const rootLocator: any = {
+    all: async () => [],
+    count: async () => 0,
+    filter: function() { return this; },
+    first: () => null,
+    page: () => ({ waitForTimeout: async () => {} }),
+  };
+
+  const filterEngine: any = {
+    applyFilters: () => ({ count: async () => 0, all: async () => [], first: () => null }),
+  };
+
+  const tableMapper: any = {
+    getMap: async () => new Map([['Name', 0]]),
+  };
+
+  const makeSmartRow = (_loc: any, _map: any, idx: number) =>
+    ({ rowIndex: idx, getCell: () => ({}), toJSON: async () => ({}) } as any);
+
+  return new RowFinder(
+    rootLocator,
+    config,
+    (_item: any, parent: any) => parent,
+    filterEngine,
+    tableMapper,
+    makeSmartRow
+  );
+}
+
+describe('RowFinder pagination delay call sites', () => {
+  beforeEach(() => {
+    debugDelaySpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('findRows calls debugDelay("pagination") once per page advance', async () => {
+    let advances = 0;
+    const config = makeConfig({
+      strategies: {
+        pagination: {
+          goNext: async () => {
+            advances++;
+            return advances < 2; // advance once then stop
+          },
+        },
+      },
+    } as any);
+
+    await makeRowFinder(config).findRows({});
+
+    const paginationCalls = debugDelaySpy.mock.calls.filter(
+      ([, action]) => action === 'pagination'
+    );
+    expect(paginationCalls.length).toBe(1);
+  });
+
+  it('findRows calls debugDelay("pagination") for each of multiple page advances', async () => {
+    let advances = 0;
+    const config = makeConfig({
+      maxPages: 4,
+      strategies: {
+        pagination: {
+          goNext: async () => {
+            advances++;
+            return advances < 3; // advance twice then stop
+          },
+        },
+      },
+    } as any);
+
+    await makeRowFinder(config).findRows({});
+
+    const paginationCalls = debugDelaySpy.mock.calls.filter(
+      ([, action]) => action === 'pagination'
+    );
+    expect(paginationCalls.length).toBe(2);
+  });
+
+  it('findRows does not call debugDelay("pagination") when no pagination strategy', async () => {
+    const config = makeConfig({ strategies: {} } as any);
+    await makeRowFinder(config).findRows({});
+
+    const paginationCalls = debugDelaySpy.mock.calls.filter(
+      ([, action]) => action === 'pagination'
+    );
+    expect(paginationCalls.length).toBe(0);
+  });
+});

--- a/tests/unit/rowFinder.pagination.delay.test.ts
+++ b/tests/unit/rowFinder.pagination.delay.test.ts
@@ -5,6 +5,7 @@
  * tests that exercise the real debugDelay implementation.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Locator, Page } from '@playwright/test';
 
 vi.mock('../../src/utils/elementTracker', () => ({
   ElementTracker: class {
@@ -25,8 +26,10 @@ vi.mock('../../src/utils/debugUtils', async (importOriginal) => {
 });
 
 import { RowFinder } from '../../src/engine/rowFinder';
+import type { FilterEngine } from '../../src/filterEngine';
+import type { TableMapper } from '../../src/engine/tableMapper';
+import type { FinalTableConfig, SmartRow, TableStrategies } from '../../src/types';
 import * as debugUtils from '../../src/utils/debugUtils';
-import type { FinalTableConfig } from '../../src/types';
 
 const debugDelaySpy = debugUtils.debugDelay as ReturnType<typeof vi.fn>;
 
@@ -37,40 +40,50 @@ function makeConfig(overrides: Partial<FinalTableConfig> = {}): FinalTableConfig
     cellSelector: 'td',
     maxPages: 3,
     autoScroll: false,
-    headerTransformer: ({ text }: any) => text,
+    headerTransformer: ({ text }) => text,
     onReset: async () => {},
-    strategies: {},
+    strategies: {} as TableStrategies,
     ...overrides,
-  } as any;
+  };
 }
 
 function makeRowFinder(config: FinalTableConfig) {
-  const rootLocator: any = {
-    all: async () => [],
-    count: async () => 0,
-    filter: function() { return this; },
-    first: () => null,
-    page: () => ({ waitForTimeout: async () => {} }),
+  const fakeLocator = {
+    all: async (): Promise<Locator[]> => [],
+    count: async (): Promise<number> => 0,
+    filter: (): Locator => fakeLocator as unknown as Locator,
+    first: (): Locator => null as unknown as Locator,
+    page: (): Page => ({ waitForTimeout: async () => {} } as unknown as Page),
   };
 
-  const filterEngine: any = {
-    applyFilters: () => ({ count: async () => 0, all: async () => [], first: () => null }),
-  };
+  const rootLocator = fakeLocator as unknown as Locator;
 
-  const tableMapper: any = {
-    getMap: async () => new Map([['Name', 0]]),
-  };
+  const filterEngine = {
+    applyFilters: (): Locator => ({
+      count: async () => 0,
+      all: async () => [],
+      first: () => null,
+    } as unknown as Locator),
+  } as unknown as FilterEngine;
 
-  const makeSmartRow = (_loc: any, _map: any, idx: number) =>
-    ({ rowIndex: idx, getCell: () => ({}), toJSON: async () => ({}) } as any);
+  const tableMapper = {
+    getMap: async (): Promise<Map<string, number>> => new Map([['Name', 0]]),
+  } as unknown as TableMapper;
+
+  const makeSmartRow = (
+    _loc: Locator,
+    _map: Map<string, number>,
+    idx: number | undefined,
+  ): SmartRow => ({ rowIndex: idx, getCell: () => ({}), toJSON: async () => ({}) } as unknown as SmartRow);
 
   return new RowFinder(
     rootLocator,
     config,
-    (_item: any, parent: any) => parent,
+    (_item, parent) => parent as Locator,
     filterEngine,
     tableMapper,
-    makeSmartRow
+    makeSmartRow,
+    { currentPageIndex: 0 },
   );
 }
 
@@ -83,25 +96,22 @@ describe('RowFinder pagination delay call sites', () => {
     vi.restoreAllMocks();
   });
 
+  // ─── findRows ──────────────────────────────────────────────────────────────
+
   it('findRows calls debugDelay("pagination") once per page advance', async () => {
     let advances = 0;
     const config = makeConfig({
       strategies: {
         pagination: {
-          goNext: async () => {
-            advances++;
-            return advances < 2; // advance once then stop
-          },
+          goNext: async () => { advances++; return advances < 2; },
         },
-      },
-    } as any);
+      } as TableStrategies,
+    });
 
     await makeRowFinder(config).findRows({});
 
-    const paginationCalls = debugDelaySpy.mock.calls.filter(
-      ([, action]) => action === 'pagination'
-    );
-    expect(paginationCalls.length).toBe(1);
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(1);
   });
 
   it('findRows calls debugDelay("pagination") for each of multiple page advances', async () => {
@@ -110,29 +120,65 @@ describe('RowFinder pagination delay call sites', () => {
       maxPages: 4,
       strategies: {
         pagination: {
-          goNext: async () => {
-            advances++;
-            return advances < 3; // advance twice then stop
-          },
+          goNext: async () => { advances++; return advances < 3; },
         },
-      },
-    } as any);
+      } as TableStrategies,
+    });
 
     await makeRowFinder(config).findRows({});
 
-    const paginationCalls = debugDelaySpy.mock.calls.filter(
-      ([, action]) => action === 'pagination'
-    );
-    expect(paginationCalls.length).toBe(2);
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(2);
   });
 
   it('findRows does not call debugDelay("pagination") when no pagination strategy', async () => {
-    const config = makeConfig({ strategies: {} } as any);
+    const config = makeConfig({ strategies: {} as TableStrategies });
     await makeRowFinder(config).findRows({});
 
-    const paginationCalls = debugDelaySpy.mock.calls.filter(
-      ([, action]) => action === 'pagination'
-    );
-    expect(paginationCalls.length).toBe(0);
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(0);
+  });
+
+  // ─── findRow (exercises findRowLocator) ────────────────────────────────────
+
+  it('findRow calls debugDelay("pagination") once when row not found after one page advance', async () => {
+    let advances = 0;
+    const config = makeConfig({
+      strategies: {
+        pagination: {
+          goNext: async () => { advances++; return advances < 2; },
+        },
+      } as TableStrategies,
+    });
+
+    await makeRowFinder(config).findRow({});
+
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(1);
+  });
+
+  it('findRow calls debugDelay("pagination") for each of multiple page advances', async () => {
+    let advances = 0;
+    const config = makeConfig({
+      maxPages: 4,
+      strategies: {
+        pagination: {
+          goNext: async () => { advances++; return advances < 3; },
+        },
+      } as TableStrategies,
+    });
+
+    await makeRowFinder(config).findRow({});
+
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(2);
+  });
+
+  it('findRow does not call debugDelay("pagination") when no pagination strategy', async () => {
+    const config = makeConfig({ strategies: {} as TableStrategies });
+    await makeRowFinder(config).findRow({});
+
+    const calls = debugDelaySpy.mock.calls.filter(([, action]) => action === 'pagination');
+    expect(calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #117 and #90 (part of #158 Group A).

- **#117** — `debug.slow.pagination` had no effect because `debugDelay(config, 'pagination')` was never called anywhere. Added the call after every successful page advance across all three call sites:
  - `_advancePage()` in `src/useTable.ts` (used by `forEach`, `map`, `filter`, and the async iterator)
  - `findRows` pagination loop in `src/engine/rowFinder.ts`
  - `findRowLocator` pagination loop in `src/engine/rowFinder.ts`

- **#90** — Added the one missing verbose entry log: `iterator: starting (maxPages=…)` to the `[Symbol.asyncIterator]` in `useTable.ts`. All other public methods already had at least one verbose log.

## Tests

- Added `RowFinder verbose logging` suite to `debugUtils.coverage.test.ts`: verifies `findRows` and `findRow` emit the expected log lines at the correct level, and that no `[SmartTable]` output appears when `logLevel: 'none'`.
- Added `tests/unit/rowFinder.pagination.delay.test.ts`: mocks `debugDelay` and asserts it is called with `'pagination'` exactly once per page advance in `findRows`, handles multiple advances, and emits no pagination calls when no pagination strategy is configured.
- All 123 unit tests pass, TypeScript clean.

## Test plan

- [x] `pnpm run test:unit` — 123 passed
- [x] `npx tsc --noEmit` — clean
- [ ] CI Group A (`playwright.config.ci-a.ts`) — verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering pagination delay behavior and verbose logging, ensuring pagination pause calls occur as expected and verbose/internal logs respect log level settings.

* **Chores**
  * Improved observability: added explicit debug pauses after page advances and enriched iterator startup and pagination logging for clearer diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->