### PR TITLE
docs(claude): always open PRs as drafts to stagger CodeRabbit reviews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,11 +96,11 @@ Running `pnpm run build` executes all generators then compiles TypeScript.
 
 ## Before Opening a PR
 
-Always rebase onto the latest main before pushing:
-
-```bash
-git fetch origin && git rebase origin/main
-```
+1. Rebase onto the latest main:
+   ```bash
+   git fetch origin && git rebase origin/main
+   ```
+2. **Always open PRs as drafts** (`gh pr create --draft`). This staggers CodeRabbit reviews and prevents hitting rate limits. Only mark ready when the PR is actually ready for review.
 
 ## PR Checklist
 
@@ -109,3 +109,4 @@ git fetch origin && git rebase origin/main
 - [ ] Commit messages follow Conventional Commits
 - [ ] `CHANGELOG.md` updated if version was bumped
 - [ ] `pnpm-lock.yaml` staged if version was bumped
+- [ ] PR opened as draft (`gh pr create --draft`)


### PR DESCRIPTION
## Summary

- Documents the draft-first PR rule in `CLAUDE.md` — both in the "Before Opening a PR" steps and the PR Checklist
- Explains the reason: staggering CodeRabbit reviews to avoid per-author rate limits

## Why draft-first

CodeRabbit rate limits are per-author. Opening multiple PRs as ready simultaneously triggers reviews in parallel and can hit the limit. Marking ready one at a time when the PR is actually ready for review keeps reviews staggered.

## Note

The `pre-push` rebase check (`.husky/pre-push`) shipped separately in #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request submission guidelines for contributors with enhanced workflow instructions and new verification checklist items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->