### PR TITLE
feat(bot): add @rickcedwhat-ai bot

### DIFF
--- a/.github/workflows/bot-dependabot-rebase.yml
+++ b/.github/workflows/bot-dependabot-rebase.yml
@@ -1,0 +1,77 @@
+name: Bot — Dependabot Rebase Scheduler
+
+# Watches for the age-check-rebase-after marker posted by dependabot-age-check.yml.
+# When found, enqueues an @dependabot rebase via QStash to fire at exactly that date.
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  schedule-rebase:
+    name: Schedule @dependabot rebase
+    runs-on: ubuntu-latest
+    # Only fire on PR comments that contain the age-check marker
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, 'age-check-rebase-after:')
+    steps:
+      - name: Parse date and enqueue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const body = context.payload.comment.body;
+            const match = body.match(/age-check-rebase-after:\s*(\d{4}-\d{2}-\d{2})/);
+            if (!match) {
+              core.info('No rebase-after date found — skipping.');
+              return;
+            }
+
+            const rebaseAfterDate = match[1];
+            const rebaseAfterMs = new Date(rebaseAfterDate).getTime();
+            const nowMs = Date.now();
+
+            if (rebaseAfterMs <= nowMs) {
+              core.info('Rebase date is in the past — skipping.');
+              return;
+            }
+
+            // Use Upstash-Not-Before (Unix timestamp in seconds) for exact timing
+            const notBefore = Math.ceil(rebaseAfterMs / 1000);
+
+            const { owner, repo } = context.repo;
+            const pr_number = context.issue.number;
+
+            const payload = JSON.stringify({
+              event_type: 'bot-dependabot-rebase',
+              client_payload: { pr_number, repo: `${owner}/${repo}` }
+            });
+
+            const DISPATCH_URL =
+              `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+
+            const res = await fetch(
+              `https://qstash.upstash.io/v2/publish/${DISPATCH_URL}`,
+              {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
+                  'Upstash-Not-Before': String(notBefore),
+                  'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
+                  'Upstash-Forward-Content-Type': 'application/json',
+                  'Content-Type': 'application/json',
+                },
+                body: payload
+              }
+            );
+
+            if (!res.ok) {
+              core.setFailed(`QStash enqueue failed: ${res.status} ${await res.text()}`);
+              return;
+            }
+
+            core.info(`@dependabot rebase scheduled for ${rebaseAfterDate} on PR #${pr_number}.`);
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -1,0 +1,331 @@
+name: Bot Listener
+
+# Handles all @rickcedwhat-ai commands posted in issue or PR comments.
+# Only fires when the comment starts with the bot mention and was not
+# posted by the bot itself (prevents loops).
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  parse:
+    name: Parse command
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.comment.body, '@rickcedwhat-ai ') &&
+      github.event.comment.user.login != 'rickcedwhat-ai'
+    outputs:
+      namespace:   ${{ steps.parse.outputs.namespace }}
+      subcommand:  ${{ steps.parse.outputs.subcommand }}
+      args:        ${{ steps.parse.outputs.args }}
+      is_pr:       ${{ steps.parse.outputs.is_pr }}
+      valid:       ${{ steps.parse.outputs.valid }}
+    steps:
+      - name: Parse command
+        id: parse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body.trim();
+            const match = body.match(/^@rickcedwhat-ai\s+(\w+)\s+(\w+)(?:\s+([\s\S]*))?$/);
+            if (!match) {
+              core.setOutput('valid', 'false');
+              return;
+            }
+            const [, namespace, subcommand, args = ''] = match;
+            core.setOutput('valid', 'true');
+            core.setOutput('namespace', namespace);
+            core.setOutput('subcommand', subcommand);
+            core.setOutput('args', args.trim());
+            core.setOutput('is_pr', String(!!context.payload.issue.pull_request));
+
+  # ── upstream watch ─────────────────────────────────────────────────────────
+  upstream-watch:
+    name: upstream watch
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'upstream' &&
+      needs.parse.outputs.subcommand == 'watch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run upstream watch
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ARGS: ${{ needs.parse.outputs.args }}
+        run: node scripts/bot-upstream-watch.mjs
+
+  # ── upstream check ─────────────────────────────────────────────────────────
+  upstream-check:
+    name: upstream check
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'upstream' &&
+      needs.parse.outputs.subcommand == 'check'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Fetch this issue as array
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          gh issue view ${{ github.event.issue.number }} \
+            --json number,body,title > /tmp/single.json
+          node -e "
+            const d = require('/tmp/single.json');
+            require('fs').writeFileSync('issues.json', JSON.stringify([d]));
+          "
+      - name: Run check
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: node scripts/check-upstream-blockers.mjs
+
+  # ── upstream schedule ──────────────────────────────────────────────────────
+  upstream-schedule:
+    name: upstream schedule
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'upstream' &&
+      needs.parse.outputs.subcommand == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enqueue upstream check via QStash
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
+          DELAY_STR:    ${{ needs.parse.outputs.args }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO:         ${{ github.repository }}
+        run: |
+          DELAY_SECS=$(node -e "
+            const s = process.env.DELAY_STR;
+            const m = s.match(/^(\d+)(m|h|d|w)$/);
+            if (!m) { console.error('Invalid delay: ' + s); process.exit(1); }
+            const mult = { m: 60, h: 3600, d: 86400, w: 604800 };
+            console.log(parseInt(m[1]) * mult[m[2]]);
+          ")
+          PAYLOAD=$(node -e "console.log(JSON.stringify({
+            event_type: 'bot-upstream-check',
+            client_payload: {
+              issue_number: parseInt(process.env.ISSUE_NUMBER),
+              repo: process.env.REPO
+            }
+          }))")
+          curl -sf -X POST \
+            "https://qstash.upstash.io/v2/publish/https://api.github.com/repos/$REPO/dispatches" \
+            -H "Authorization: Bearer $QSTASH_TOKEN" \
+            -H "Upstash-Delay: ${DELAY_SECS}s" \
+            -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
+            -H "Upstash-Forward-Content-Type: application/json" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+      - name: Confirm
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `⏱️ Upstream check scheduled in **${{ needs.parse.outputs.args }}**.`
+            });
+
+  # ── upstream link ──────────────────────────────────────────────────────────
+  upstream-link:
+    name: upstream link
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'upstream' &&
+      needs.parse.outputs.subcommand == 'link'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update blocked-pr in issue body
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const args = `${{ needs.parse.outputs.args }}`;
+            const prMatch = args.match(/#?(\d+)/);
+            if (!prMatch) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '❌ Could not parse PR number. Usage: `@rickcedwhat-ai upstream link pr #N`'
+              });
+              return;
+            }
+            const prNumber = prMatch[1];
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            let body = issue.body || '';
+            if (/^blocked-pr:/m.test(body)) {
+              body = body.replace(/^blocked-pr:.*$/m, `blocked-pr: "#${prNumber}"`);
+            } else {
+              body = body.replace(/(condition:[^\n]*)/m, `$1\nblocked-pr: "#${prNumber}"`);
+            }
+            await github.rest.issues.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number, body
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🔗 Linked blocked PR to #${prNumber}.`
+            });
+
+  # ── upstream unblock ───────────────────────────────────────────────────────
+  upstream-unblock:
+    name: upstream unblock
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'upstream' &&
+      needs.parse.outputs.subcommand == 'unblock'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark cleared
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number, name: 'upstream-blocker:waiting'
+              });
+            } catch {}
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number, labels: ['upstream-blocker:cleared']
+            });
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: '✅ Marked as cleared manually.'
+            });
+
+  # ── coderabbit retry ───────────────────────────────────────────────────────
+  coderabbit-retry:
+    name: coderabbit retry
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'coderabbit' &&
+      needs.parse.outputs.subcommand == 'retry' &&
+      needs.parse.outputs.is_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enqueue CodeRabbit review via QStash
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
+          DELAY_STR:    ${{ needs.parse.outputs.args }}
+          PR_NUMBER:    ${{ github.event.issue.number }}
+          REPO:         ${{ github.repository }}
+        run: |
+          DELAY_SECS=$(node -e "
+            const s = process.env.DELAY_STR;
+            const m = s.match(/^(\d+)(m|h|d|w)$/);
+            if (!m) { console.error('Invalid delay: ' + s); process.exit(1); }
+            const mult = { m: 60, h: 3600, d: 86400, w: 604800 };
+            console.log(parseInt(m[1]) * mult[m[2]]);
+          ")
+          PAYLOAD=$(node -e "console.log(JSON.stringify({
+            event_type: 'bot-coderabbit-retry',
+            client_payload: {
+              pr_number: parseInt(process.env.PR_NUMBER),
+              repo: process.env.REPO
+            }
+          }))")
+          curl -sf -X POST \
+            "https://qstash.upstash.io/v2/publish/https://api.github.com/repos/$REPO/dispatches" \
+            -H "Authorization: Bearer $QSTASH_TOKEN" \
+            -H "Upstash-Delay: ${DELAY_SECS}s" \
+            -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
+            -H "Upstash-Forward-Content-Type: application/json" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+      - name: Confirm
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `⏱️ CodeRabbit review scheduled in **${{ needs.parse.outputs.args }}**.`
+            });
+
+  # ── help / unknown ─────────────────────────────────────────────────────────
+  help:
+    name: help
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'help'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post help
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                '### @rickcedwhat-ai commands',
+                '',
+                '**On issues:**',
+                '| Command | Description |',
+                '|---|---|',
+                '| `@rickcedwhat-ai upstream watch npm <pkg> >= <version>` | Register upstream check + add `:waiting` label |',
+                '| `@rickcedwhat-ai upstream check` | Immediate semver check for this issue |',
+                '| `@rickcedwhat-ai upstream schedule <delay>` | Re-check after delay (e.g. `2w`, `3d`) |',
+                '| `@rickcedwhat-ai upstream link pr #N` | Link a blocked PR to this issue |',
+                '| `@rickcedwhat-ai upstream unblock` | Manually mark this issue as cleared |',
+                '',
+                '**On PRs:**',
+                '| Command | Description |',
+                '|---|---|',
+                '| `@rickcedwhat-ai coderabbit retry <delay>` | Schedule a CodeRabbit review after delay (e.g. `36m`) |',
+              ].join('\n')
+            });
+
+  unknown-command:
+    name: Unknown command
+    needs: parse
+    if: needs.parse.outputs.valid == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post unknown command message
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❓ Unknown command. Comment `@rickcedwhat-ai help` to see available commands.'
+            });

--- a/.github/workflows/bot-pr-linker.yml
+++ b/.github/workflows/bot-pr-linker.yml
@@ -1,0 +1,52 @@
+name: Bot — PR Issue Linker
+
+# Reminds the author to add a "Closes #N" reference when a non-draft PR
+# is opened or converted from draft without linking an issue.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  check-link:
+    name: Check for issue link
+    runs-on: ubuntu-latest
+    # Skip Dependabot PRs — they never have issue links
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Check PR body for issue reference
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const hasLink = /(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i.test(body);
+            if (hasLink) {
+              core.info('Issue reference found — no reminder needed.');
+              return;
+            }
+
+            // Check if we already posted this reminder (avoid duplicate comments)
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+            const alreadyPosted = comments.some(
+              c => c.user.login === 'rickcedwhat-ai' &&
+                   c.body.includes('link this PR to an issue')
+            );
+            if (alreadyPosted) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                '👋 Heads up — this PR doesn\'t appear to link to an issue.',
+                'If it closes one, add a `Closes #N` line to the PR description so',
+                'the issue closes automatically on merge and stays tracked in the work queue.',
+                '',
+                '_If this PR intentionally has no linked issue, ignore this message._',
+              ].join('\n')
+            });

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -1,0 +1,104 @@
+name: Bot Receiver
+
+# Handles delayed actions delivered by QStash via repository_dispatch.
+# QStash calls the GitHub dispatches API directly after the configured delay.
+
+on:
+  repository_dispatch:
+    types:
+      - bot-coderabbit-retry
+      - bot-upstream-check
+      - bot-upstream-nudge
+      - bot-dependabot-rebase
+
+jobs:
+  # ── coderabbit retry ───────────────────────────────────────────────────────
+  coderabbit-retry:
+    name: Post CodeRabbit review
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-coderabbit-retry'
+    steps:
+      - name: Post @coderabbitai full review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+            await github.rest.issues.createComment({
+              owner,
+              repo: repoName,
+              issue_number: pr_number,
+              body: '@coderabbitai full review'
+            });
+
+  # ── upstream check (scheduled) ─────────────────────────────────────────────
+  upstream-check:
+    name: Run scheduled upstream check
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-upstream-check'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Prepare single-issue input
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          ISSUE_NUMBER: ${{ github.event.client_payload.issue_number }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" --json number,body,title > /tmp/single.json
+          node -e "
+            const d = require('/tmp/single.json');
+            require('fs').writeFileSync('issues.json', JSON.stringify([d]));
+          "
+      - name: Run check
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: node scripts/check-upstream-blockers.mjs
+
+  # ── upstream nudge (48h after cleared) ────────────────────────────────────
+  upstream-nudge:
+    name: Post upstream nudge
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-upstream-nudge'
+    steps:
+      - name: Check if still unstarted and nudge
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { issue_number, blocked_pr, repo } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+
+            // Only nudge if the issue is still open
+            const { data: issue } = await github.rest.issues.get({
+              owner, repo: repoName, issue_number
+            });
+            if (issue.state !== 'open') return;
+
+            const prRef = blocked_pr ? ` (PR #${blocked_pr})` : '';
+            await github.rest.issues.createComment({
+              owner, repo: repoName, issue_number,
+              body: `⏰ Reminder: the upstream blocker for this issue was cleared 48 hours ago${prRef} — ready to start?`
+            });
+
+  # ── dependabot rebase ──────────────────────────────────────────────────────
+  dependabot-rebase:
+    name: Post @dependabot rebase
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-dependabot-rebase'
+    steps:
+      - name: Post @dependabot rebase
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+            await github.rest.issues.createComment({
+              owner,
+              repo: repoName,
+              issue_number: pr_number,
+              body: '@dependabot rebase'
+            });

--- a/.github/workflows/bot-upstream-cleared.yml
+++ b/.github/workflows/bot-upstream-cleared.yml
@@ -1,0 +1,76 @@
+name: Bot — Upstream Blocker Cleared
+
+# When upstream-blocker:cleared is applied (by the weekly cron or manually),
+# notify the linked blocked PR and schedule a 48h nudge if no action is taken.
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    name: Notify blocked PR and schedule nudge
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'upstream-blocker:cleared'
+    steps:
+      - name: Parse blocked-pr and notify
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            // Extract blocked-pr from yaml block
+            const prMatch = body.match(/^blocked-pr:\s*"?#?(\d+)"?/m);
+            const blockedPr = prMatch ? prMatch[1] : null;
+
+            if (blockedPr) {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: parseInt(blockedPr),
+                body: [
+                  `🟢 **Upstream blocker cleared** — issue #${issue.number} is unblocked.`,
+                  '',
+                  'This PR can now be resumed.',
+                ].join('\n')
+              });
+            }
+
+            // Enqueue 48h nudge via QStash
+            const payload = JSON.stringify({
+              event_type: 'bot-upstream-nudge',
+              client_payload: {
+                issue_number: issue.number,
+                blocked_pr: blockedPr || null,
+                repo: `${owner}/${repo}`
+              }
+            });
+
+            const DELAY_SECS = 48 * 60 * 60; // 48 hours
+            const DISPATCH_URL =
+              `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+
+            const res = await fetch(
+              `https://qstash.upstash.io/v2/publish/${DISPATCH_URL}`,
+              {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
+                  'Upstash-Delay': `${DELAY_SECS}s`,
+                  'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
+                  'Upstash-Forward-Content-Type': 'application/json',
+                  'Content-Type': 'application/json',
+                },
+                body: payload
+              }
+            );
+            if (!res.ok) {
+              core.warning(`QStash enqueue failed: ${res.status} ${await res.text()}`);
+            } else {
+              core.info('48h nudge enqueued via QStash.');
+            }
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT: ${{ secrets.BOT_PAT }}

--- a/scripts/bot-upstream-watch.mjs
+++ b/scripts/bot-upstream-watch.mjs
@@ -1,0 +1,82 @@
+/**
+ * Handles `@rickcedwhat-ai upstream watch npm <pkg> >= <version>`.
+ *
+ * - Parses the package and semver condition from ARGS
+ * - Writes (or updates) the upstream-check yaml block in the issue body
+ * - Adds the upstream-blocker:waiting label
+ * - Posts a confirmation comment
+ *
+ * Environment:
+ *   GH_TOKEN      — bot PAT (write access to issues)
+ *   ISSUE_NUMBER  — the issue to update
+ *   ARGS          — everything after "upstream watch", e.g. "npm vitepress >= 2.0.0"
+ */
+
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+
+const issueNumber = process.env.ISSUE_NUMBER;
+const args = (process.env.ARGS || '').trim();
+
+// Parse: npm <package> <operator> <version>
+const match = args.match(/^npm\s+(\S+)\s+(>=|<=|>|<|=~|\^|~)\s*(\S+)$/);
+if (!match) {
+  console.error(`Could not parse args: "${args}"`);
+  console.error('Expected format: npm <package> >= <version>');
+  process.exit(1);
+}
+const [, pkg, op, version] = match;
+
+// Fetch current issue body
+const issue = JSON.parse(
+  execSync(`gh issue view ${issueNumber} --json body,title`, { encoding: 'utf8' })
+);
+
+const yamlBlock =
+  '```yaml\n' +
+  `type: npm\n` +
+  `package: ${pkg}\n` +
+  `condition: latest ${op} ${version}\n` +
+  '```';
+
+const detailsBlock =
+  '<details>\n' +
+  '<summary>upstream-check</summary>\n\n' +
+  `${yamlBlock}\n\n` +
+  '</details>';
+
+let body = issue.body || '';
+
+// Replace existing upstream-check details block, or append
+if (/<details>\s*<summary>upstream-check<\/summary>[\s\S]*?<\/details>/m.test(body)) {
+  body = body.replace(
+    /<details>\s*<summary>upstream-check<\/summary>[\s\S]*?<\/details>/m,
+    detailsBlock
+  );
+} else {
+  body = body.trimEnd() + '\n\n' + detailsBlock;
+}
+
+// Write updated body to a temp file to avoid shell quoting issues
+writeFileSync('/tmp/issue-body.md', body);
+execSync(`gh issue edit ${issueNumber} --body-file /tmp/issue-body.md`);
+
+// Add label
+try {
+  execSync(`gh issue edit ${issueNumber} --add-label "upstream-blocker:waiting"`, {
+    stdio: 'pipe'
+  });
+} catch (e) {
+  console.warn(`Could not add label: ${e.message}`);
+}
+
+// Post confirmation
+const comment =
+  `🔍 Now watching **${pkg}** — will notify when \`latest ${op} ${version}\`.\n\n` +
+  `Added \`upstream-blocker:waiting\` label.\n\n` +
+  `_Checked every Monday at 09:00 UTC. Use \`@rickcedwhat-ai upstream check\` to run immediately._`;
+
+writeFileSync('/tmp/bot-comment.md', comment);
+execSync(`gh issue comment ${issueNumber} --body-file /tmp/bot-comment.md`);
+
+console.log(`upstream watch registered: ${pkg} ${op} ${version} on issue #${issueNumber}`);


### PR DESCRIPTION
## Summary

Implements the `@rickcedwhat-ai` bot across five workflows and one supporting script.

### Commands (via issue/PR comment)

| Command | What it does |
|---|---|
| `@rickcedwhat-ai upstream watch npm <pkg> >= <version>` | Writes yaml block into issue body, adds `:waiting` label |
| `@rickcedwhat-ai upstream check` | Immediately runs the semver check for this issue |
| `@rickcedwhat-ai upstream schedule <delay>` | Re-checks after delay (e.g. `2w`, `3d`) via QStash |
| `@rickcedwhat-ai upstream link pr #N` | Updates `blocked-pr` field in issue yaml block |
| `@rickcedwhat-ai upstream unblock` | Manually marks issue as cleared |
| `@rickcedwhat-ai coderabbit retry <delay>` | Schedules `@coderabbitai full review` after delay via QStash |
| `@rickcedwhat-ai help` | Posts command reference |

### Automatic integrations

| Trigger | Action |
|---|---|
| `upstream-blocker:cleared` label applied | Comments on the `blocked-pr` that work can resume |
| 48h after `:cleared` with no PR activity | QStash nudge posted on the issue |
| Age-check posts `age-check-rebase-after: YYYY-MM-DD` | `@dependabot rebase` auto-scheduled via QStash for that exact date |
| Non-draft PR opened without `Closes #N` | Reminder comment posted |

### Files

- `.github/workflows/bot-listener.yml` — command router
- `.github/workflows/bot-receiver.yml` — QStash delivery handler
- `.github/workflows/bot-upstream-cleared.yml` — cleared label reactor
- `.github/workflows/bot-dependabot-rebase.yml` — dependabot rebase scheduler
- `.github/workflows/bot-pr-linker.yml` — issue link reminder
- `scripts/bot-upstream-watch.mjs` — upstream watch handler

## Required setup before merging

See checklist below — secrets must be added first or all bot workflows will fail silently.

## Test plan

- [ ] `BOT_PAT` and `QSTASH_TOKEN` secrets added to this repo
- [ ] `rickcedwhat-ai` has collaborator access (write) on this repo
- [ ] Comment `@rickcedwhat-ai help` on any issue — bot replies with command list
- [ ] Comment `@rickcedwhat-ai upstream watch npm vitepress >= 2.0.0` on issue #118 — yaml block appears, label applied
- [ ] Comment `@rickcedwhat-ai upstream check` on issue #118 — immediate check runs
- [ ] Comment `@rickcedwhat-ai coderabbit retry 2m` on any PR — CodeRabbit review posted ~2 minutes later
- [ ] Open a test PR without `Closes #N` — linker reminder appears
- [ ] Verify `bot-dependabot-rebase.yml` fires when age-check posts its marker comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)