### PR TITLE
fix(bot): surface QStash error response on failure

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -126,14 +126,20 @@ jobs:
               repo: process.env.REPO
             }
           }))")
-          curl -sf -X POST \
-            "https://qstash.upstash.io/v2/publish/https://api.github.com/repos/$REPO/dispatches" \
+          DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
+          HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
+            "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
             -H "Authorization: Bearer $QSTASH_TOKEN" \
             -H "Upstash-Delay: ${DELAY_SECS}s" \
             -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
             -H "Upstash-Forward-Content-Type: application/json" \
             -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+            -d "$PAYLOAD")
+          echo "QStash response ($HTTP_CODE): $(cat /tmp/qstash-response.json)"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "QStash enqueue failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
       - name: Confirm
         uses: actions/github-script@v7
         with:
@@ -255,14 +261,20 @@ jobs:
               repo: process.env.REPO
             }
           }))")
-          curl -sf -X POST \
-            "https://qstash.upstash.io/v2/publish/https://api.github.com/repos/$REPO/dispatches" \
+          DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
+          HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
+            "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
             -H "Authorization: Bearer $QSTASH_TOKEN" \
             -H "Upstash-Delay: ${DELAY_SECS}s" \
             -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
             -H "Upstash-Forward-Content-Type: application/json" \
             -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+            -d "$PAYLOAD")
+          echo "QStash response ($HTTP_CODE): $(cat /tmp/qstash-response.json)"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "QStash enqueue failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
       - name: Confirm
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/bot-pr-linker.yml
+++ b/.github/workflows/bot-pr-linker.yml
@@ -5,7 +5,7 @@ name: Bot — PR Issue Linker
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened]
 
 jobs:
   check-link:
@@ -34,7 +34,7 @@ jobs:
             });
             const alreadyPosted = comments.some(
               c => c.user.login === 'rickcedwhat-ai' &&
-                   c.body.includes('link this PR to an issue')
+                   c.body.includes('intentionally has no linked issue')
             );
             if (alreadyPosted) return;
 


### PR DESCRIPTION
## Summary

- `coderabbit retry` and `upstream schedule` curl calls were using `-sf` which swallows the QStash error response body, making failures show only as exit code 22 with no diagnosis — replaced with `-s -o -w "%{http_code}"` pattern so the actual error is logged
- PR linker was posting duplicate comments: dedup string didn't match actual comment body, and `ready_for_review` trigger caused double-firing — fixed both

## Closes
Follow-up to #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)