### PR TITLE
fix(bot): reminder command reads delay from subcommand not args

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -349,8 +349,8 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            const args = `${{ needs.parse.outputs.args }}`.trim();
-            if (!args || !/^\d+(m|h|d|w)$/.test(args)) {
+            const delay = `${{ needs.parse.outputs.subcommand }}`.trim();
+            if (!delay || !/^\d+(m|h|d|w)$/.test(delay)) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -363,7 +363,7 @@ jobs:
         env:
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
           BOT_PAT:      ${{ secrets.BOT_PAT }}
-          DELAY_STR:    ${{ needs.parse.outputs.args }}
+          DELAY_STR:    ${{ needs.parse.outputs.subcommand }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO:         ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Summary

- `@rickcedwhat-ai reminder 2h` was incorrectly failing with "Please specify a delay" because the parser puts `2h` into `subcommand` (not `args`) for single-argument commands
- Validate step and enqueue step in the `reminder` job now read `subcommand` as the delay value

## Root cause

The two-word parser regex captures `namespace subcommand [args...]`. For `@rickcedwhat-ai reminder 2h`, that means namespace=`reminder`, subcommand=`2h`, args=`''`. Both steps were reading the empty `args` field.

## Test plan

- [ ] Comment `@rickcedwhat-ai reminder 5m` on an issue — should get 👍 reaction, reminder posts after 5 minutes
- [ ] Comment `@rickcedwhat-ai reminder 2h` — same flow, no error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)