### PR TITLE
chore: make scarf analytics opt-in (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - **Unit tests for `mapColumn` / `getColumnValues`** — Dedicated Vitest unit tests covering single-column extraction, whitespace trimming, empty-table edge case, `bringIntoView` call verification, `columnOverrides.read` delegation, column-not-found error (including fuzzy-match suggestions), and `maxPages` option. Closes #84.
 
+### Changed
+- **Scarf telemetry is now opt-in** — `scarfSettings.defaultOptIn` is set to `false` in `package.json`. No install analytics are collected unless consumers explicitly opt in. A telemetry disclosure has been added to the README. Closes #106.
+
 ## [6.12.0] - 2026-05-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Unit tests for `mapColumn` / `getColumnValues`** — Dedicated Vitest unit tests covering single-column extraction, whitespace trimming, empty-table edge case, `bringIntoView` call verification, `columnOverrides.read` delegation, column-not-found error (including fuzzy-match suggestions), and `maxPages` option. Closes #84.
 
 ### Changed
-- **Scarf telemetry is now opt-in** — `scarfSettings.defaultOptIn` is set to `false` in `package.json`. No install analytics are collected unless consumers explicitly opt in. A telemetry disclosure has been added to the README. Closes #106.
+- **Removed `@scarf/scarf`** — Install-time telemetry dependency removed entirely. No analytics are collected. Closes #106.
 
 ## [6.12.0] - 2026-05-05
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ await table.forEach(async ({ row }) => {
 npm install @rickcedwhat/playwright-smart-table
 ```
 
+> **Telemetry notice:** This package includes [`@scarf/scarf`](https://scarf.sh/) for anonymous install analytics. Telemetry is **opt-in** — nothing is collected unless you explicitly enable it. To opt in, add the following to your `package.json`:
+>
+> ```json
+> "scarfSettings": { "defaultOptIn": true }
+> ```
+>
+> Alternatively, set the environment variable `SCARF_ANALYTICS=false` to disable any analytics at install time.
+
 ## Quick Start
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -45,13 +45,6 @@ await table.forEach(async ({ row }) => {
 npm install @rickcedwhat/playwright-smart-table
 ```
 
-> **Telemetry notice:** This package includes [`@scarf/scarf`](https://scarf.sh/) for anonymous install analytics. Telemetry is **opt-in** — nothing is collected unless you explicitly enable it. To opt in, add the following to your `package.json`:
->
-> ```json
-> "scarfSettings": { "defaultOptIn": true }
-> ```
->
-> Alternatively, set the environment variable `SCARF_ANALYTICS=false` to disable any analytics at install time.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
     "vitepress": "^1.6.4",
     "vitest": "^3.2.4"
   },
+  "scarfSettings": {
+    "defaultOptIn": false
+  },
   "dependencies": {
     "@scarf/scarf": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -97,11 +97,5 @@
     "vitepress": "^1.6.4",
     "vitest": "^3.2.4"
   },
-  "scarfSettings": {
-    "defaultOptIn": false
-  },
-  "dependencies": {
-    "@scarf/scarf": "^1.4.0"
-  },
   "packageManager": "pnpm@10.33.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@scarf/scarf':
-        specifier: ^1.4.0
-        version: 1.4.0
     devDependencies:
       '@commitlint/cli':
         specifier: ^21.0.0
@@ -846,9 +842,6 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
-
-  '@scarf/scarf@1.4.0':
-    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -2999,8 +2992,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
-
-  '@scarf/scarf@1.4.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 


### PR DESCRIPTION
## Summary

- Sets `scarfSettings.defaultOptIn: false` in `package.json` so Scarf collects no install analytics unless consumers explicitly opt in
- Adds a telemetry disclosure notice to `README.md` under the Installation section, explaining how to opt in and how to disable via `SCARF_ANALYTICS=false`
- Adds `[Unreleased]` section to `CHANGELOG.md`

Closes #106

## Test plan

- [x] `pnpm run build` passes
- [ ] Verify that installing the package in a fresh project does not trigger any Scarf outbound call (no network activity on `postinstall`)
- [ ] Verify the README telemetry section renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)