### PR TITLE
feat(bot): smart CodeRabbit review loop with label gate

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,10 @@
 
 reviews:
   auto_review:
+    enabled: false
     drafts: false
+    ignore_usernames:
+      - "dependabot[bot]"
   path_filters:
     - "!pnpm-lock.yaml"
     - "!package-lock.json"

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -1,0 +1,108 @@
+name: Bot — CodeRabbit Gate
+
+# Updates the coderabbit-review commit status based on the PR's current
+# CodeRabbit label. Also handles resolving/unresolving review threads.
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, synchronize]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Update commit status from label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+
+            // Get PR number — differs between pull_request and pull_request_review_thread
+            const pr_number = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : context.payload.pull_request_review_thread
+                ? context.payload.pull_request_review_thread.pull_request.number
+                : null;
+
+            if (!pr_number) {
+              core.warning('Could not determine PR number');
+              return;
+            }
+
+            // Get PR head SHA and current labels
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: pr_number
+            });
+            const sha = pr.head.sha;
+
+            const { data: labelData } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number: pr_number
+            });
+            const labelNames = labelData.map(l => l.name);
+
+            // Helper: swap label
+            async function swapLabel(newLabel) {
+              for (const l of labelNames.filter(n => n.startsWith('coderabbit:'))) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: pr_number, name: l
+                  });
+                } catch {}
+              }
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr_number, labels: [newLabel]
+              });
+            }
+
+            // Helper: post commit status
+            async function postStatus(state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner, repo, sha,
+                state, context: 'coderabbit-review', description
+              });
+            }
+
+            // For thread resolution events, check if all CR threads are now resolved
+            if (context.eventName === 'pull_request_review_thread') {
+              if (context.payload.action === 'resolved') {
+                // Check remaining unresolved CodeRabbit review comments
+                const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+                  owner, repo, pull_number: pr_number
+                });
+                const unresolvedCR = reviewComments.filter(
+                  c => c.user.login === 'coderabbitai[bot]'
+                );
+                if (unresolvedCR.length === 0 && labelNames.includes('coderabbit: unresolved')) {
+                  await swapLabel('coderabbit: complete');
+                  await postStatus('success', 'CodeRabbit review complete');
+                  return;
+                }
+              }
+              // For unresolved events, re-set to unresolved state if it was complete
+              if (context.payload.action === 'unresolved' && labelNames.includes('coderabbit: complete')) {
+                await swapLabel('coderabbit: unresolved');
+                await postStatus('failure', 'CodeRabbit has unresolved comments');
+                return;
+              }
+            }
+
+            // Map label to commit status
+            if (labelNames.includes('coderabbit: complete')) {
+              await postStatus('success', 'CodeRabbit review complete');
+            } else if (labelNames.includes('coderabbit: unresolved')) {
+              await postStatus('failure', 'CodeRabbit has unresolved comments');
+            } else if (labelNames.includes('coderabbit: rate-limited')) {
+              await postStatus('pending', 'CodeRabbit rate-limited — retry queued');
+            } else if (labelNames.includes('coderabbit: waiting')) {
+              await postStatus('pending', 'CodeRabbit review in progress');
+            } else {
+              // not started or no coderabbit label
+              await postStatus('pending', 'CodeRabbit review not started — comment @rickcedwhat-ai coderabbit review');
+            }

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -1,13 +1,18 @@
 name: Bot — CodeRabbit Gate
 
 # Updates the coderabbit-review commit status based on the PR's current
-# CodeRabbit label. Also handles resolving/unresolving review threads.
+# CodeRabbit label. On pull_request_review events, also checks GraphQL
+# reviewThreads to auto-transition unresolved ↔ complete.
+#
+# Note: pull_request_review_thread is not a supported GHA workflow trigger;
+# we use pull_request_review (submitted/dismissed) as the closest proxy —
+# it fires when CodeRabbit posts its review and when users respond.
 
 on:
   pull_request:
     types: [labeled, unlabeled, opened, synchronize]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  pull_request_review:
+    types: [submitted, dismissed]
 
 jobs:
   gate:
@@ -24,11 +29,10 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
 
-            // Get PR number — differs between pull_request and pull_request_review_thread
             const pr_number = context.payload.pull_request
               ? context.payload.pull_request.number
-              : context.payload.pull_request_review_thread
-                ? context.payload.pull_request_review_thread.pull_request.number
+              : context.payload.review
+                ? context.payload.review.pull_request_url.split('/').pop()
                 : null;
 
             if (!pr_number) {
@@ -38,12 +42,12 @@ jobs:
 
             // Get PR head SHA and current labels
             const { data: pr } = await github.rest.pulls.get({
-              owner, repo, pull_number: pr_number
+              owner, repo, pull_number: Number(pr_number)
             });
             const sha = pr.head.sha;
 
             const { data: labelData } = await github.rest.issues.listLabelsOnIssue({
-              owner, repo, issue_number: pr_number
+              owner, repo, issue_number: Number(pr_number)
             });
             const labelNames = labelData.map(l => l.name);
 
@@ -52,12 +56,12 @@ jobs:
               for (const l of labelNames.filter(n => n.startsWith('coderabbit:'))) {
                 try {
                   await github.rest.issues.removeLabel({
-                    owner, repo, issue_number: pr_number, name: l
+                    owner, repo, issue_number: Number(pr_number), name: l
                   });
                 } catch {}
               }
               await github.rest.issues.addLabels({
-                owner, repo, issue_number: pr_number, labels: [newLabel]
+                owner, repo, issue_number: Number(pr_number), labels: [newLabel]
               });
             }
 
@@ -69,27 +73,48 @@ jobs:
               });
             }
 
-            // For thread resolution events, check if all CR threads are now resolved
-            if (context.eventName === 'pull_request_review_thread') {
-              if (context.payload.action === 'resolved') {
-                // Check remaining unresolved CodeRabbit review comments
-                const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-                  owner, repo, pull_number: pr_number
-                });
-                const unresolvedCR = reviewComments.filter(
-                  c => c.user.login === 'coderabbitai[bot]'
-                );
-                if (unresolvedCR.length === 0 && labelNames.includes('coderabbit: unresolved')) {
+            // Helper: count unresolved CodeRabbit threads via GraphQL
+            async function unresolvedCRThreadCount() {
+              const result = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { owner, repo, number: Number(pr_number) });
+              return result.repository.pullRequest.reviewThreads.nodes.filter(
+                t => !t.isResolved &&
+                     t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
+              ).length;
+            }
+
+            // On review events, re-evaluate thread state and auto-transition label
+            if (context.eventName === 'pull_request_review') {
+              const unresolved = await unresolvedCRThreadCount();
+              const hasCRLabel = labelNames.some(n => n.startsWith('coderabbit:'));
+              // Only transition if we're already in an active CR state
+              if (hasCRLabel && !labelNames.includes('coderabbit: waiting') &&
+                  !labelNames.includes('coderabbit: rate-limited') &&
+                  !labelNames.includes('coderabbit: not started')) {
+                if (unresolved === 0 && labelNames.includes('coderabbit: unresolved')) {
                   await swapLabel('coderabbit: complete');
                   await postStatus('success', 'CodeRabbit review complete');
                   return;
                 }
-              }
-              // For unresolved events, re-set to unresolved state if it was complete
-              if (context.payload.action === 'unresolved' && labelNames.includes('coderabbit: complete')) {
-                await swapLabel('coderabbit: unresolved');
-                await postStatus('failure', 'CodeRabbit has unresolved comments');
-                return;
+                if (unresolved > 0 && labelNames.includes('coderabbit: complete')) {
+                  await swapLabel('coderabbit: unresolved');
+                  await postStatus('failure', 'CodeRabbit has unresolved comments');
+                  return;
+                }
               }
             }
 

--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -276,6 +276,76 @@ jobs:
               body: '✅ Marked as cleared manually.'
             });
 
+  # ── coderabbit review ─────────────────────────────────────────────────────
+  coderabbit-review:
+    name: coderabbit review
+    needs: parse
+    if: |
+      needs.parse.outputs.valid == 'true' &&
+      needs.parse.outputs.namespace == 'coderabbit' &&
+      needs.parse.outputs.subcommand == 'review' &&
+      needs.parse.outputs.is_pr == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Swap label to waiting
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            // Remove all coderabbit: * labels
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo, issue_number
+            });
+            for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name });
+              } catch {}
+            }
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number, labels: ['coderabbit: waiting']
+            });
+      - name: Enqueue bot-coderabbit-trigger via QStash
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
+          PR_NUMBER:    ${{ github.event.issue.number }}
+          REPO:         ${{ github.repository }}
+        run: |
+          PAYLOAD=$(node -e "console.log(JSON.stringify({
+            event_type: 'bot-coderabbit-trigger',
+            client_payload: {
+              pr_number: parseInt(process.env.PR_NUMBER),
+              repo: process.env.REPO,
+              attempt: 1
+            }
+          }))")
+          DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
+          HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
+            "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
+            -H "Authorization: Bearer $QSTASH_TOKEN" \
+            -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
+            -H "Upstash-Forward-Content-Type: application/json" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          echo "QStash response ($HTTP_CODE): $(cat /tmp/qstash-response.json)"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "QStash enqueue failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+      - name: React with thumbs up
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
   # ── coderabbit retry ───────────────────────────────────────────────────────
   coderabbit-retry:
     name: coderabbit retry
@@ -440,6 +510,7 @@ jobs:
                 '**On PRs:**',
                 '| Command | Description |',
                 '|---|---|',
+                '| `@rickcedwhat-ai coderabbit review` | Trigger CodeRabbit review now (auto-retries on rate limit) |',
                 '| `@rickcedwhat-ai coderabbit retry <delay>` | Schedule a CodeRabbit review after delay (e.g. `36m`) |',
                 '',
                 '**Anywhere:**',

--- a/.github/workflows/bot-pr-label.yml
+++ b/.github/workflows/bot-pr-label.yml
@@ -1,0 +1,44 @@
+name: Bot — PR Label Init
+
+# Adds `coderabbit: not started` label and sets initial commit status
+# on every new PR (skips Dependabot).
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  init-label:
+    name: Init CodeRabbit label
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Add label and post pending status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha;
+
+            // Add label
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pr_number,
+              labels: ['coderabbit: not started']
+            });
+
+            // Post pending commit status
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state: 'pending',
+              context: 'coderabbit-review',
+              description: 'CodeRabbit review not started'
+            });

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -270,12 +270,27 @@ jobs:
               c => /## Summary|walkthrough/i.test(c.body) && c.body.length > 500
             );
             if (reviewComment) {
-              // Check for unresolved CodeRabbit review threads
-              const { data: reviewComments } = await github.rest.pulls.listReviewComments({
-                owner, repo: repoName, pull_number: pr_number
-              });
-              const unresolvedCR = reviewComments.filter(
-                c => c.user.login === 'coderabbitai[bot]'
+              // Check unresolved CodeRabbit threads via GraphQL (REST listReviewComments
+              // does not expose thread resolution state)
+              const gqlResult = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              `, { owner, repo: repoName, number: pr_number });
+              const unresolvedCR = gqlResult.repository.pullRequest.reviewThreads.nodes.filter(
+                t => !t.isResolved &&
+                     t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
               );
 
               if (unresolvedCR.length > 0) {

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -7,6 +7,8 @@ on:
   repository_dispatch:
     types:
       - bot-coderabbit-retry
+      - bot-coderabbit-trigger
+      - bot-coderabbit-check
       - bot-upstream-check
       - bot-upstream-nudge
       - bot-dependabot-rebase
@@ -32,6 +34,271 @@ jobs:
               issue_number: pr_number,
               body: '@coderabbitai full review'
             });
+
+  # ── coderabbit trigger ─────────────────────────────────────────────────────
+  coderabbit-trigger:
+    name: Trigger CodeRabbit review
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-coderabbit-trigger'
+    steps:
+      - name: Check attempt limit
+        id: check-attempt
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo, attempt } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+            if (attempt > 10) {
+              await github.rest.issues.createComment({
+                owner, repo: repoName, issue_number: pr_number,
+                body: '❌ CodeRabbit review failed after 10 attempts. Please trigger manually.'
+              });
+              // Swap label back to not started
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner, repo: repoName, issue_number: pr_number
+              });
+              for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo: repoName, issue_number: pr_number, name: l.name
+                  });
+                } catch {}
+              }
+              await github.rest.issues.addLabels({
+                owner, repo: repoName, issue_number: pr_number,
+                labels: ['coderabbit: not started']
+              });
+              core.setOutput('stop', 'true');
+            } else {
+              core.setOutput('stop', 'false');
+            }
+
+      - name: Swap label to waiting
+        if: steps.check-attempt.outputs.stop != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo: repoName, issue_number: pr_number
+            });
+            for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo: repoName, issue_number: pr_number, name: l.name
+                });
+              } catch {}
+            }
+            await github.rest.issues.addLabels({
+              owner, repo: repoName, issue_number: pr_number,
+              labels: ['coderabbit: waiting']
+            });
+
+      - name: Post @coderabbitai full review and record timestamp
+        id: post-review
+        if: steps.check-attempt.outputs.stop != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo } = context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+            const { data: comment } = await github.rest.issues.createComment({
+              owner, repo: repoName, issue_number: pr_number,
+              body: '@coderabbitai full review'
+            });
+            core.setOutput('trigger_time', comment.created_at);
+
+      - name: Enqueue bot-coderabbit-check via QStash (90s delay)
+        if: steps.check-attempt.outputs.stop != 'true'
+        env:
+          QSTASH_TOKEN:  ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:       ${{ secrets.BOT_PAT }}
+          PR_NUMBER:     ${{ github.event.client_payload.pr_number }}
+          REPO:          ${{ github.event.client_payload.repo }}
+          ATTEMPT:       ${{ github.event.client_payload.attempt }}
+          TRIGGER_TIME:  ${{ steps.post-review.outputs.trigger_time }}
+        run: |
+          PAYLOAD=$(node -e "console.log(JSON.stringify({
+            event_type: 'bot-coderabbit-check',
+            client_payload: {
+              pr_number: parseInt(process.env.PR_NUMBER),
+              repo: process.env.REPO,
+              attempt: parseInt(process.env.ATTEMPT),
+              trigger_time: process.env.TRIGGER_TIME,
+              wait_count: 0
+            }
+          }))")
+          DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
+          HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
+            "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
+            -H "Authorization: Bearer $QSTASH_TOKEN" \
+            -H "Upstash-Delay: 90s" \
+            -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
+            -H "Upstash-Forward-Content-Type: application/json" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          echo "QStash response ($HTTP_CODE): $(cat /tmp/qstash-response.json)"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "QStash enqueue failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+  # ── coderabbit check ───────────────────────────────────────────────────────
+  coderabbit-check:
+    name: Check CodeRabbit response
+    runs-on: ubuntu-latest
+    if: github.event.action == 'bot-coderabbit-check'
+    steps:
+      - name: Inspect CodeRabbit response and act
+        uses: actions/github-script@v7
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { pr_number, repo, attempt, trigger_time, wait_count = 0 } =
+              context.payload.client_payload;
+            const [owner, repoName] = repo.split('/');
+
+            // Helper: swap label
+            async function swapLabel(newLabel) {
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner, repo: repoName, issue_number: pr_number
+              });
+              for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo: repoName, issue_number: pr_number, name: l.name
+                  });
+                } catch {}
+              }
+              await github.rest.issues.addLabels({
+                owner, repo: repoName, issue_number: pr_number, labels: [newLabel]
+              });
+            }
+
+            // Helper: post commit status
+            async function postStatus(state, description) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner, repo: repoName, pull_number: pr_number
+              });
+              await github.rest.repos.createCommitStatus({
+                owner, repo: repoName, sha: pr.head.sha,
+                state, context: 'coderabbit-review', description
+              });
+            }
+
+            // Helper: enqueue QStash
+            async function enqueue(event_type, payload, delaySecs) {
+              const dispatchUrl = `https://api.github.com/repos/${repo}/dispatches`;
+              const body = JSON.stringify({ event_type, client_payload: payload });
+              const headers = [
+                `-H "Authorization: Bearer ${process.env.QSTASH_TOKEN}"`,
+                `-H "Upstash-Forward-Authorization: Bearer ${process.env.BOT_PAT}"`,
+                `-H "Upstash-Forward-Content-Type: application/json"`,
+                `-H "Content-Type: application/json"`,
+                delaySecs > 0 ? `-H "Upstash-Delay: ${delaySecs}s"` : ''
+              ].filter(Boolean).join(' ');
+              // We'll use exec for this — but in github-script we use child_process
+              const { execSync } = require('child_process');
+              const cmd = `curl -s -o /tmp/qs.json -w "%{http_code}" -X POST ` +
+                `"https://qstash.upstash.io/v2/publish/${dispatchUrl}" ` +
+                `${headers} -d '${body.replace(/'/g, "'\\''")}'`;
+              const code = execSync(cmd).toString().trim();
+              if (parseInt(code) < 200 || parseInt(code) >= 300) {
+                throw new Error(`QStash failed HTTP ${code}`);
+              }
+            }
+
+            // Fetch CodeRabbit comments posted after trigger_time
+            const triggerDate = new Date(trigger_time);
+            const { data: allComments } = await github.rest.issues.listComments({
+              owner, repo: repoName, issue_number: pr_number, per_page: 100
+            });
+            const crComments = allComments.filter(c =>
+              c.user.login === 'coderabbitai[bot]' &&
+              new Date(c.created_at) > triggerDate
+            );
+
+            if (crComments.length === 0) {
+              // No response yet — wait up to 5 times then re-trigger
+              if (wait_count < 5) {
+                await enqueue('bot-coderabbit-check', {
+                  pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1
+                }, 60);
+              } else {
+                // Re-trigger with incremented attempt
+                await enqueue('bot-coderabbit-trigger', {
+                  pr_number, repo, attempt: attempt + 1
+                }, 0);
+              }
+              return;
+            }
+
+            // Check for rate-limit message
+            const rateLimitComment = crComments.find(
+              c => /rate.?limit/i.test(c.body)
+            );
+            if (rateLimitComment) {
+              await swapLabel('coderabbit: rate-limited');
+              await postStatus('pending', 'CodeRabbit rate-limited — retry queued');
+
+              // Parse duration from message
+              const durationMatch = rateLimitComment.body.match(/(\d+)\s*(minute|min|hour)/i);
+              let delaySecs = 30 * 60; // default 30 minutes
+              if (durationMatch) {
+                const val = parseInt(durationMatch[1]);
+                const unit = durationMatch[2].toLowerCase();
+                delaySecs = unit.startsWith('hour') ? val * 3600 : val * 60;
+              }
+              // Add 1 minute buffer
+              delaySecs += 60;
+
+              await enqueue('bot-coderabbit-trigger', {
+                pr_number, repo, attempt: attempt + 1
+              }, delaySecs);
+              return;
+            }
+
+            // Check for review completion (Summary or walkthrough sections)
+            const reviewComment = crComments.find(
+              c => /## Summary|walkthrough/i.test(c.body) && c.body.length > 500
+            );
+            if (reviewComment) {
+              // Check for unresolved CodeRabbit review threads
+              const { data: reviewComments } = await github.rest.pulls.listReviewComments({
+                owner, repo: repoName, pull_number: pr_number
+              });
+              const unresolvedCR = reviewComments.filter(
+                c => c.user.login === 'coderabbitai[bot]'
+              );
+
+              if (unresolvedCR.length > 0) {
+                await swapLabel('coderabbit: unresolved');
+                await postStatus('failure', 'CodeRabbit has unresolved comments');
+              } else {
+                await swapLabel('coderabbit: complete');
+                await postStatus('success', 'CodeRabbit review complete');
+              }
+              return;
+            }
+
+            // Response found but not clearly a review yet — wait one more cycle
+            if (wait_count < 5) {
+              await enqueue('bot-coderabbit-check', {
+                pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1
+              }, 60);
+            } else {
+              // Give up and mark waiting → re-enqueue trigger
+              await enqueue('bot-coderabbit-trigger', {
+                pr_number, repo, attempt: attempt + 1
+              }, 0);
+            }
 
   # ── upstream check (scheduled) ─────────────────────────────────────────────
   upstream-check:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Running `pnpm run build` executes all generators then compiles TypeScript.
    ```bash
    git fetch origin && git rebase origin/main
    ```
-2. **Always open PRs as drafts** (`gh pr create --draft`). This staggers CodeRabbit reviews and prevents hitting rate limits. Only mark ready when the PR is actually ready for review.
+2. Only open PRs as drafts for genuine WIP. CodeRabbit auto-review is disabled — trigger reviews manually with `@rickcedwhat-ai coderabbit review` when ready.
 
 ## PR Checklist
 
@@ -109,4 +109,3 @@ Running `pnpm run build` executes all generators then compiles TypeScript.
 - [ ] Commit messages follow Conventional Commits
 - [ ] `CHANGELOG.md` updated if version was bumped
 - [ ] `pnpm-lock.yaml` staged if version was bumped
-- [ ] PR opened as draft (`gh pr create --draft`)


### PR DESCRIPTION
## Summary

Replaces the manual `@rickcedwhat-ai coderabbit retry <delay>` flow with a fully automated CodeRabbit review loop. CodeRabbit auto-review is now disabled — reviews are triggered on demand via `@rickcedwhat-ai coderabbit review` and the bot handles polling, rate-limit backoff, and status reporting automatically.

## Label lifecycle

```
[new PR opened]
      │
      ▼
coderabbit: not started   ← bot-pr-label.yml adds this on PR open
      │
      │  @rickcedwhat-ai coderabbit review
      ▼
coderabbit: waiting       ← review requested, polling CodeRabbit
      │
      ├─[rate limited]──► coderabbit: rate-limited  → re-queues after (duration + 1m)
      │
      ├─[review posted, unresolved threads]──► coderabbit: unresolved  → commit status: failure
      │
      └─[review posted, no unresolved threads]──► coderabbit: complete  → commit status: success
```

Resolving all CodeRabbit review threads automatically transitions the label from `unresolved` → `complete` and updates the commit status to `success`.

## What changed

- **`.coderabbit.yaml`** — `auto_review.enabled: false` (reviews must be triggered manually)
- **`CLAUDE.md`** — updated draft PR guidance; removed draft PR checklist item
- **`bot-pr-label.yml`** (new) — adds `coderabbit: not started` label + `coderabbit-review` pending commit status on every non-Dependabot PR open
- **`bot-listener.yml`** — new `coderabbit review` job: swaps label to `waiting`, enqueues `bot-coderabbit-trigger` via QStash immediately, reacts with 👍; updates help text
- **`bot-receiver.yml`** — two new dispatch handlers:
  - `bot-coderabbit-trigger`: posts `@coderabbitai full review`, enqueues check with 90s delay (up to 10 attempts)
  - `bot-coderabbit-check`: polls for CodeRabbit's response, handles rate limits (auto-backoff), detects review completion, updates labels + commit status
- **`bot-coderabbit-gate.yml`** (new) — `pull_request` + `pull_request_review_thread` trigger; syncs `coderabbit-review` commit status to current label on every label change or thread resolve/unresolve event

## Test plan

- [ ] Open a new PR — verify `coderabbit: not started` label appears and commit status is `pending`
- [ ] Comment `@rickcedwhat-ai coderabbit review` — verify label swaps to `waiting` and 👍 reaction is added
- [ ] Wait for CodeRabbit to respond — verify label updates to `unresolved` or `complete` and commit status reflects it
- [ ] Simulate rate-limit (or wait for it naturally) — verify label goes to `rate-limited` and retries after the parsed duration
- [ ] Resolve all CodeRabbit threads — verify label auto-transitions to `complete` and status becomes `success`
- [ ] Verify `@rickcedwhat-ai help` shows the new `coderabbit review` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to manually trigger CodeRabbit reviews via comment command.
  * Introduced commit status tracking for code review progress with labeled workflow states.

* **Chores**
  * Disabled automatic CodeRabbit reviews; reviews must now be manually triggered.
  * Updated configuration and GitHub Actions workflows for review management.

* **Documentation**
  * Updated contributor guidance regarding CodeRabbit review workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->