### PR TITLE
feat(smart-cell): export SmartCell type and wire beforeCellRead into bringIntoView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **`SmartCell` type and `getCell()` drop-in upgrade** — `SmartRow.getCell(column)` now returns a `SmartCell` (a `Locator` extended with `bringIntoView(): Promise<void>`). Calling `bringIntoView()` runs the full single-cell navigation pipeline (`_navigateToCell` + `beforeCellRead` hook), so `expect(row.getCell('Region')).toHaveText(...)` works correctly on horizontally virtualized grids without any extra boilerplate. `SmartCell` is exported from the package's public surface. Closes #43.
 - **Unit tests for `mapColumn` / `getColumnValues`** — Dedicated Vitest unit tests covering single-column extraction, whitespace trimming, empty-table edge case, `bringIntoView` call verification, `columnOverrides.read` delegation, column-not-found error (including fuzzy-match suggestions), and `maxPages` option. Closes #84.
 
 ### Changed

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type {
     TableConfig,
     TableResult,
     SmartRow,
+    SmartCell,
     Selector,
     FilterValue,
     PaginationPrimitives,

--- a/src/smartRow.ts
+++ b/src/smartRow.ts
@@ -426,10 +426,11 @@ const createSmartRow = <T = any>(
 
         const smartCell = baseLocator as SmartCell;
         smartCell.bringIntoView = async () => {
+            const page = rootLocator.page();
             const navigatedCell = await _navigateToCell({
                 config,
                 rootLocator,
-                page: rootLocator.page(),
+                page,
                 resolve,
                 getHeaders: table?.getHeaders,
                 column: colName,
@@ -440,6 +441,26 @@ const createSmartRow = <T = any>(
             });
             if (navigatedCell && (navigatedCell as any)._locator) {
                 (smartCell as any)._locator = (navigatedCell as any)._locator;
+            }
+
+            // Run beforeCellRead hook (same as toJSON does after navigation).
+            if (config.strategies.beforeCellRead) {
+                const getHeaderCell = table?.getHeaderCell
+                    ? table.getHeaderCell.bind(table)
+                    : async (colNameArg: string) => {
+                        const i = map.get(colNameArg);
+                        if (i === undefined) throw new Error(`Column "${colNameArg}" not found`);
+                        return resolve(config.headerSelector as any, rootLocator).nth(i);
+                    };
+                await config.strategies.beforeCellRead({
+                    cell: navigatedCell ?? baseLocator,
+                    columnName: colName,
+                    columnIndex: idx,
+                    row: rowLocator,
+                    page,
+                    root: rootLocator,
+                    getHeaderCell,
+                });
             }
         };
 

--- a/src/smartRow.ts
+++ b/src/smartRow.ts
@@ -439,10 +439,6 @@ const createSmartRow = <T = any>(
                 rowIndex,
                 barrier: (smart as any)._barrier
             });
-            if (navigatedCell && (navigatedCell as any)._locator) {
-                (smartCell as any)._locator = (navigatedCell as any)._locator;
-            }
-
             // Run beforeCellRead hook (same as toJSON does after navigation).
             if (config.strategies.beforeCellRead) {
                 const getHeaderCell = table?.getHeaderCell

--- a/tests/unit/smartCell.unit.test.ts
+++ b/tests/unit/smartCell.unit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import createSmartRow from '../../src/smartRow';
+import { FinalTableConfig } from '../../src/types';
+
+/**
+ * Minimal Locator-like mock used across tests.
+ */
+function makeMockLocator(overrides: Record<string, any> = {}) {
+    const loc: Record<string, any> = {
+        count: vi.fn().mockResolvedValue(1),
+        nth: vi.fn().mockReturnThis(),
+        page: vi.fn().mockReturnValue({
+            keyboard: { press: vi.fn() },
+            waitForTimeout: vi.fn(),
+        }),
+        evaluate: vi.fn(),
+        scrollIntoViewIfNeeded: vi.fn(),
+        innerText: vi.fn().mockResolvedValue('cell text'),
+        focus: vi.fn(),
+        ...overrides,
+    };
+    // Make nth() return a new object each call so locator chaining works
+    loc.nth = vi.fn().mockReturnValue(loc);
+    return loc;
+}
+
+function makeConfig(overrides: Partial<FinalTableConfig<any>> = {}): FinalTableConfig<any> {
+    return {
+        rowSelector: 'tr',
+        headerSelector: 'th',
+        cellSelector: 'td',
+        strategies: {},
+        debug: { logLevel: 'none' },
+        ...overrides,
+    } as FinalTableConfig<any>;
+}
+
+describe('SmartCell', () => {
+    describe('getCell() return value', () => {
+        it('returns an object with a bringIntoView method', () => {
+            const loc = makeMockLocator();
+            const config = makeConfig();
+            const map = new Map([['Name', 0]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            const cell = row.getCell('Name');
+            expect(typeof cell.bringIntoView).toBe('function');
+        });
+
+        it('throws when column does not exist', () => {
+            const loc = makeMockLocator();
+            const config = makeConfig();
+            const map = new Map([['Name', 0]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            expect(() => row.getCell('NonExistent')).toThrow(/NonExistent/);
+        });
+
+        it('uses getCellLocator strategy when provided', () => {
+            const loc = makeMockLocator();
+            const customCell = makeMockLocator();
+            const getCellLocator = vi.fn().mockReturnValue(customCell);
+            const config = makeConfig({ strategies: { getCellLocator } });
+            const map = new Map([['Email', 1]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            row.getCell('Email');
+            expect(getCellLocator).toHaveBeenCalledWith(
+                expect.objectContaining({ columnName: 'Email', columnIndex: 1 })
+            );
+        });
+    });
+
+    describe('SmartCell.bringIntoView()', () => {
+        it('resolves without error for a simple (non-virtualized) table', async () => {
+            const loc = makeMockLocator();
+            const config = makeConfig();
+            const map = new Map([['Name', 0]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            await expect(row.getCell('Name').bringIntoView()).resolves.toBeUndefined();
+        });
+
+        it('calls beforeCellRead with correct args after navigation', async () => {
+            const loc = makeMockLocator();
+            const beforeCellRead = vi.fn().mockResolvedValue(undefined);
+            const config = makeConfig({ strategies: { beforeCellRead } });
+            const map = new Map([['Region', 2]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            await row.getCell('Region').bringIntoView();
+            expect(beforeCellRead).toHaveBeenCalledOnce();
+            const args = beforeCellRead.mock.calls[0][0];
+            expect(args.columnName).toBe('Region');
+            expect(args.columnIndex).toBe(2);
+            expect(typeof args.getHeaderCell).toBe('function');
+        });
+
+        it('does NOT call beforeCellRead when strategy is absent', async () => {
+            const loc = makeMockLocator();
+            const config = makeConfig({ strategies: {} });
+            const map = new Map([['Status', 0]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            // Should not throw
+            await expect(row.getCell('Status').bringIntoView()).resolves.toBeUndefined();
+        });
+
+        it('calls viewport.scrollToColumn when column is out of visible range', async () => {
+            const scrollToColumn = vi.fn().mockResolvedValue(undefined);
+            const loc = makeMockLocator({
+                // First count() call returns 0 (not yet in DOM), second returns 1 (after scroll)
+                count: vi.fn()
+                    .mockResolvedValueOnce(0)  // targetReached check before scroll
+                    .mockResolvedValue(1),     // targetReached check after scroll
+            });
+            const config = makeConfig({
+                strategies: {
+                    viewport: {
+                        getVisibleColumnRange: vi.fn()
+                            .mockResolvedValue({ first: 0, last: 2 }),
+                        scrollToColumn,
+                    },
+                },
+            });
+            const map = new Map([['FarRight', 5]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            await row.getCell('FarRight').bringIntoView();
+            expect(scrollToColumn).toHaveBeenCalledWith(expect.anything(), 5);
+        });
+
+        it('forwards getHeaderCell from table reference when available', async () => {
+            const loc = makeMockLocator();
+            const beforeCellRead = vi.fn().mockResolvedValue(undefined);
+            const mockHeaderCell = makeMockLocator();
+            const getHeaderCell = vi.fn().mockResolvedValue(mockHeaderCell);
+            const config = makeConfig({ strategies: { beforeCellRead } });
+            const map = new Map([['City', 3]]);
+            const mockTable = { getHeaderCell, getHeaders: vi.fn() } as any;
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, mockTable);
+            await row.getCell('City').bringIntoView();
+            // getHeaderCell from the table should be passed through
+            const passedGetHeaderCell = beforeCellRead.mock.calls[0][0].getHeaderCell;
+            await passedGetHeaderCell('City');
+            expect(getHeaderCell).toHaveBeenCalledWith('City');
+        });
+    });
+
+    describe('SmartCell is a drop-in Locator replacement', () => {
+        it('exposes standard Locator properties (innerText, count, nth, etc.)', () => {
+            const loc = makeMockLocator();
+            const config = makeConfig();
+            const map = new Map([['Name', 0]]);
+            const row = createSmartRow(loc, map, 0, config, loc, (_sel, parent) => loc as any, null);
+            const cell = row.getCell('Name');
+            // SmartCell is a branded Locator — these methods must exist
+            expect(typeof cell.innerText).toBe('function');
+            expect(typeof cell.count).toBe('function');
+            expect(typeof cell.nth).toBe('function');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- **Export `SmartCell` from public index** — `SmartCell` was already defined in `types.ts` and used internally but was not re-exported from `src/index.ts`. Consumers can now import and type cell references directly.
- **Wire `beforeCellRead` into `SmartCell.bringIntoView()`** — Previously `bringIntoView()` called `_navigateToCell` but skipped the `beforeCellRead` hook that `toJSON()` runs post-navigation. This caused `expect(row.getCell('Region')).toHaveText(...)` to time out on horizontally virtualized grids whose columns need a scroll-and-settle step. Now `bringIntoView()` is fully equivalent to the per-cell path in `toJSON`.
- **9 unit tests** covering drop-in Locator surface, `bringIntoView` basic resolution, `beforeCellRead` invocation and arg forwarding, absent-strategy no-op, `viewport.scrollToColumn` trigger, and `getHeaderCell` forwarding from the table reference.

## Test plan

- [x] `pnpm run test:unit` — 175 tests pass (9 new)
- [x] `pnpm run build` — compiles cleanly, all auto-generated files up to date
- [x] Rebased onto latest `main` before push

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `SmartCell` type: `SmartRow.getCell(column)` now returns an enhanced cell object with a `bringIntoView()` method that executes the complete cell navigation pipeline.
  * The `bringIntoView()` method automatically handles horizontal virtualization and invokes pre-read hooks, eliminating manual setup for text expectations on virtualized grids.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->