### PR TITLE
fix(bot): detect CR edits via updated_at + add @rickcedwhat-ai review alias

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -29,12 +29,16 @@ jobs:
           script: |
             const body = context.payload.comment.body.trim();
 
-            // Single-word commands: help
-            const single = body.match(/^@rickcedwhat-ai\s+(help)$/);
+            // Single-word commands: help, review (alias for coderabbit review)
+            const single = body.match(/^@rickcedwhat-ai\s+(help|review)$/);
             if (single) {
+              const word = single[1];
+              // 'review' is a shorthand alias for 'coderabbit review'
+              const namespace = word === 'review' ? 'coderabbit' : word;
+              const subcommand = word === 'review' ? 'review' : '';
               core.setOutput('valid', 'true');
-              core.setOutput('namespace', single[1]);
-              core.setOutput('subcommand', '');
+              core.setOutput('namespace', namespace);
+              core.setOutput('subcommand', subcommand);
               core.setOutput('args', '');
               core.setOutput('is_pr', String(!!context.payload.issue.pull_request));
               return;
@@ -510,7 +514,7 @@ jobs:
                 '**On PRs:**',
                 '| Command | Description |',
                 '|---|---|',
-                '| `@rickcedwhat-ai coderabbit review` | Trigger CodeRabbit review now (auto-retries on rate limit) |',
+                '| `@rickcedwhat-ai review` | Trigger CodeRabbit review now (auto-retries on rate limit) |',
                 '| `@rickcedwhat-ai coderabbit retry <delay>` | Schedule a CodeRabbit review after delay (e.g. `36m`) |',
                 '',
                 '**Anywhere:**',

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -222,7 +222,7 @@ jobs:
             });
             const crComments = allComments.filter(c =>
               c.user.login === 'coderabbitai[bot]' &&
-              new Date(c.created_at) > triggerDate
+              (new Date(c.created_at) > triggerDate || new Date(c.updated_at) > triggerDate)
             );
 
             if (crComments.length === 0) {


### PR DESCRIPTION
## Summary

- **`bot-receiver`**: CodeRabbit edits its existing summary comment instead of posting a new one after `@coderabbitai full review`. The check was filtering by `created_at > triggerDate` and never found a response, causing endless retries. Now also checks `updated_at > triggerDate`.

- **`bot-listener`**: `@rickcedwhat-ai review` was rejected as unknown. Added `review` as a single-word alias → `namespace=coderabbit, subcommand=review`. Updated help text to show the shorter form.

## Test plan
- [ ] Trigger `@rickcedwhat-ai review` on a PR — should react 👍 and fire the CR flow
- [ ] After CodeRabbit finishes, label should transition from `coderabbit: waiting` → `complete` or `unresolved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)