### PR TITLE
feat(bot): living status comment + 180s first-check window

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -291,78 +291,69 @@ jobs:
       needs.parse.outputs.is_pr == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Swap label to waiting
+      - name: Swap label, post status comment, enqueue, and react
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
+          PR_NUMBER:    ${{ github.event.issue.number }}
+          REPO:         ${{ github.repository }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
+            const { execSync } = require('child_process');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            // Remove all coderabbit: * labels
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner, repo, issue_number
-            });
-            for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name });
-              } catch {}
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const repoFull = process.env.REPO;
+
+            // 1. Swap label to waiting
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number });
+            for (const l of currentLabels.filter(l => l.name.startsWith('coderabbit:'))) {
+              try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name }); } catch {}
             }
-            await github.rest.issues.addLabels({
-              owner, repo, issue_number, labels: ['coderabbit: waiting']
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['coderabbit: waiting'] });
+
+            // 2. Create status comment
+            const { data: statusComment } = await github.rest.issues.createComment({
+              owner, repo, issue_number, body: '🔄 CodeRabbit review triggered'
             });
-      - name: Post status comment
-        id: post-status
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.BOT_PAT }}
-          script: |
-            const { data: comment } = await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: '🔄 CodeRabbit review triggered'
+
+            // 3. Enqueue via QStash — if this fails, roll back label and delete comment
+            const payload = JSON.stringify({
+              event_type: 'bot-coderabbit-trigger',
+              client_payload: { pr_number: prNumber, repo: repoFull, attempt: 1, status_comment_id: statusComment.id }
             });
-            core.setOutput('comment_id', comment.id);
-      - name: Enqueue bot-coderabbit-trigger via QStash
-        env:
-          QSTASH_TOKEN:      ${{ secrets.QSTASH_TOKEN }}
-          BOT_PAT:           ${{ secrets.BOT_PAT }}
-          PR_NUMBER:         ${{ github.event.issue.number }}
-          REPO:              ${{ github.repository }}
-          STATUS_COMMENT_ID: ${{ steps.post-status.outputs.comment_id }}
-        run: |
-          PAYLOAD=$(node -e "console.log(JSON.stringify({
-            event_type: 'bot-coderabbit-trigger',
-            client_payload: {
-              pr_number: parseInt(process.env.PR_NUMBER),
-              repo: process.env.REPO,
-              attempt: 1,
-              status_comment_id: parseInt(process.env.STATUS_COMMENT_ID)
+            const dispatchUrl = `https://api.github.com/repos/${repoFull}/dispatches`;
+            const cmd = `curl -s -o /tmp/qs.json -w "%{http_code}" -X POST ` +
+              `"https://qstash.upstash.io/v2/publish/${dispatchUrl}" ` +
+              `-H "Authorization: Bearer ${process.env.QSTASH_TOKEN}" ` +
+              `-H "Upstash-Forward-Authorization: Bearer ${process.env.BOT_PAT}" ` +
+              `-H "Upstash-Forward-Content-Type: application/json" ` +
+              `-H "Content-Type: application/json" ` +
+              `-d '${payload.replace(/'/g, "'\\''")}'`;
+            let httpCode;
+            try {
+              httpCode = execSync(cmd).toString().trim();
+            } catch (e) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: statusComment.id });
+              for (const l of (await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number })).data.filter(l => l.name.startsWith('coderabbit:'))) {
+                try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name }); } catch {}
+              }
+              throw new Error(`QStash enqueue failed: ${e.message}`);
             }
-          }))")
-          DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
-          HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
-            "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
-            -H "Authorization: Bearer $QSTASH_TOKEN" \
-            -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
-            -H "Upstash-Forward-Content-Type: application/json" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")
-          echo "QStash response ($HTTP_CODE): $(cat /tmp/qstash-response.json)"
-          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-            echo "QStash enqueue failed with HTTP $HTTP_CODE"
-            exit 1
-          fi
-      - name: React with thumbs up
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.BOT_PAT }}
-          script: |
+            if (parseInt(httpCode) < 200 || parseInt(httpCode) >= 300) {
+              const body = require('fs').readFileSync('/tmp/qs.json', 'utf8');
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: statusComment.id });
+              for (const l of (await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number })).data.filter(l => l.name.startsWith('coderabbit:'))) {
+                try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name }); } catch {}
+              }
+              throw new Error(`QStash enqueue failed HTTP ${httpCode}: ${body}`);
+            }
+
+            // 4. React with thumbs up on the original command comment
             await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '+1'
+              owner, repo, comment_id: context.payload.comment.id, content: '+1'
             });
 
   # ── coderabbit retry ───────────────────────────────────────────────────────

--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -310,19 +310,34 @@ jobs:
             await github.rest.issues.addLabels({
               owner, repo, issue_number, labels: ['coderabbit: waiting']
             });
+      - name: Post status comment
+        id: post-status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { data: comment } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '🔄 CodeRabbit review triggered'
+            });
+            core.setOutput('comment_id', comment.id);
       - name: Enqueue bot-coderabbit-trigger via QStash
         env:
-          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
-          BOT_PAT:      ${{ secrets.BOT_PAT }}
-          PR_NUMBER:    ${{ github.event.issue.number }}
-          REPO:         ${{ github.repository }}
+          QSTASH_TOKEN:      ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:           ${{ secrets.BOT_PAT }}
+          PR_NUMBER:         ${{ github.event.issue.number }}
+          REPO:              ${{ github.repository }}
+          STATUS_COMMENT_ID: ${{ steps.post-status.outputs.comment_id }}
         run: |
           PAYLOAD=$(node -e "console.log(JSON.stringify({
             event_type: 'bot-coderabbit-trigger',
             client_payload: {
               pr_number: parseInt(process.env.PR_NUMBER),
               repo: process.env.REPO,
-              attempt: 1
+              attempt: 1,
+              status_comment_id: parseInt(process.env.STATUS_COMMENT_ID)
             }
           }))")
           DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -107,23 +107,35 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            const { pr_number, repo } = context.payload.client_payload;
+            const { pr_number, repo, attempt, status_comment_id } = context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
             const { data: comment } = await github.rest.issues.createComment({
               owner, repo: repoName, issue_number: pr_number,
               body: '@coderabbitai full review'
             });
             core.setOutput('trigger_time', comment.created_at);
+            // Update the living status comment to show we're waiting
+            if (status_comment_id) {
+              try {
+                await github.rest.issues.updateComment({
+                  owner, repo: repoName, comment_id: status_comment_id,
+                  body: `⏳ Waiting for CodeRabbit response... _(attempt ${attempt})_`
+                });
+              } catch (e) {
+                core.warning(`Could not update status comment: ${e.message}`);
+              }
+            }
 
-      - name: Enqueue bot-coderabbit-check via QStash (90s delay)
+      - name: Enqueue bot-coderabbit-check via QStash (180s delay)
         if: steps.check-attempt.outputs.stop != 'true'
         env:
-          QSTASH_TOKEN:  ${{ secrets.QSTASH_TOKEN }}
-          BOT_PAT:       ${{ secrets.BOT_PAT }}
-          PR_NUMBER:     ${{ github.event.client_payload.pr_number }}
-          REPO:          ${{ github.event.client_payload.repo }}
-          ATTEMPT:       ${{ github.event.client_payload.attempt }}
-          TRIGGER_TIME:  ${{ steps.post-review.outputs.trigger_time }}
+          QSTASH_TOKEN:      ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:           ${{ secrets.BOT_PAT }}
+          PR_NUMBER:         ${{ github.event.client_payload.pr_number }}
+          REPO:              ${{ github.event.client_payload.repo }}
+          ATTEMPT:           ${{ github.event.client_payload.attempt }}
+          TRIGGER_TIME:      ${{ steps.post-review.outputs.trigger_time }}
+          STATUS_COMMENT_ID: ${{ github.event.client_payload.status_comment_id }}
         run: |
           PAYLOAD=$(node -e "console.log(JSON.stringify({
             event_type: 'bot-coderabbit-check',
@@ -132,14 +144,15 @@ jobs:
               repo: process.env.REPO,
               attempt: parseInt(process.env.ATTEMPT),
               trigger_time: process.env.TRIGGER_TIME,
-              wait_count: 0
+              wait_count: 0,
+              status_comment_id: process.env.STATUS_COMMENT_ID ? parseInt(process.env.STATUS_COMMENT_ID) : undefined
             }
           }))")
           DISPATCH_URL="https://api.github.com/repos/$REPO/dispatches"
           HTTP_CODE=$(curl -s -o /tmp/qstash-response.json -w "%{http_code}" -X POST \
             "https://qstash.upstash.io/v2/publish/$DISPATCH_URL" \
             -H "Authorization: Bearer $QSTASH_TOKEN" \
-            -H "Upstash-Delay: 90s" \
+            -H "Upstash-Delay: 180s" \
             -H "Upstash-Forward-Authorization: Bearer $BOT_PAT" \
             -H "Upstash-Forward-Content-Type: application/json" \
             -H "Content-Type: application/json" \
@@ -164,7 +177,7 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            const { pr_number, repo, attempt, trigger_time, wait_count = 0 } =
+            const { pr_number, repo, attempt, trigger_time, wait_count = 0, status_comment_id } =
               context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
 
@@ -194,6 +207,18 @@ jobs:
                 owner, repo: repoName, sha: pr.head.sha,
                 state, context: 'coderabbit-review', description
               });
+            }
+
+            // Helper: edit the living status comment (no-op if no comment_id)
+            async function updateStatus(body) {
+              if (!status_comment_id) return;
+              try {
+                await github.rest.issues.updateComment({
+                  owner, repo: repoName, comment_id: status_comment_id, body
+                });
+              } catch (e) {
+                core.warning(`Could not update status comment: ${e.message}`);
+              }
             }
 
             // Helper: enqueue QStash
@@ -231,13 +256,14 @@ jobs:
             if (crComments.length === 0) {
               // No response yet — wait up to 5 times then re-trigger
               if (wait_count < 5) {
+                await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
                 await enqueue('bot-coderabbit-check', {
-                  pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1
+                  pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1, status_comment_id
                 }, 60);
               } else {
-                // Re-trigger with incremented attempt
+                await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
                 await enqueue('bot-coderabbit-trigger', {
-                  pr_number, repo, attempt: attempt + 1
+                  pr_number, repo, attempt: attempt + 1, status_comment_id
                 }, 0);
               }
               return;
@@ -262,8 +288,9 @@ jobs:
               // Add 1 minute buffer
               delaySecs += 60;
 
+              await updateStatus(`⚠️ Rate limited — retrying in ~${Math.round(delaySecs / 60)}m`);
               await enqueue('bot-coderabbit-trigger', {
-                pr_number, repo, attempt: attempt + 1
+                pr_number, repo, attempt: attempt + 1, status_comment_id
               }, delaySecs);
               return;
             }
@@ -299,22 +326,25 @@ jobs:
               if (unresolvedCR.length > 0) {
                 await swapLabel('coderabbit: unresolved');
                 await postStatus('failure', 'CodeRabbit has unresolved comments');
+                await updateStatus(`⚠️ Review complete — ${unresolvedCR.length} unresolved thread${unresolvedCR.length > 1 ? 's' : ''} remain`);
               } else {
                 await swapLabel('coderabbit: complete');
                 await postStatus('success', 'CodeRabbit review complete');
+                await updateStatus('✅ No actionable comments — review complete');
               }
               return;
             }
 
             // Response found but not clearly a review yet — wait one more cycle
             if (wait_count < 5) {
+              await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
               await enqueue('bot-coderabbit-check', {
-                pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1
+                pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1, status_comment_id
               }, 60);
             } else {
-              // Give up and mark waiting → re-enqueue trigger
+              await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
               await enqueue('bot-coderabbit-trigger', {
-                pr_number, repo, attempt: attempt + 1
+                pr_number, repo, attempt: attempt + 1, status_comment_id
               }, 0);
             }
 

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -250,7 +250,8 @@ jobs:
             });
             const crComments = allComments.filter(c =>
               c.user.login === 'coderabbitai[bot]' &&
-              (new Date(c.created_at) > triggerDate || new Date(c.updated_at) > triggerDate)
+              (new Date(c.created_at) > triggerDate || new Date(c.updated_at) > triggerDate) &&
+              !/Full review triggered/.test(c.body)  // exclude trigger acknowledgments — they are never actionable
             );
 
             if (crComments.length === 0) {

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -47,13 +47,22 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            const { pr_number, repo, attempt } = context.payload.client_payload;
+            const { pr_number, repo, attempt, status_comment_id } = context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
             if (attempt > 10) {
               await github.rest.issues.createComment({
                 owner, repo: repoName, issue_number: pr_number,
                 body: '❌ CodeRabbit review failed after 10 attempts. Please trigger manually.'
               });
+              // Update the living status comment to reflect final failure
+              if (status_comment_id) {
+                try {
+                  await github.rest.issues.updateComment({
+                    owner, repo: repoName, comment_id: status_comment_id,
+                    body: '❌ Review failed after 10 attempts — please trigger manually'
+                  });
+                } catch {}
+              }
               // Swap label back to not started
               const { data: labels } = await github.rest.issues.listLabelsOnIssue({
                 owner, repo: repoName, issue_number: pr_number
@@ -257,15 +266,15 @@ jobs:
             if (crComments.length === 0) {
               // No response yet — wait up to 5 times then re-trigger
               if (wait_count < 5) {
-                await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
                 await enqueue('bot-coderabbit-check', {
                   pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1, status_comment_id
                 }, 60);
+                await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
               } else {
-                await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
                 await enqueue('bot-coderabbit-trigger', {
                   pr_number, repo, attempt: attempt + 1, status_comment_id
                 }, 0);
+                await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
               }
               return;
             }
@@ -289,10 +298,10 @@ jobs:
               // Add 1 minute buffer
               delaySecs += 60;
 
-              await updateStatus(`⚠️ Rate limited — retrying in ~${Math.round(delaySecs / 60)}m`);
               await enqueue('bot-coderabbit-trigger', {
                 pr_number, repo, attempt: attempt + 1, status_comment_id
               }, delaySecs);
+              await updateStatus(`⚠️ Rate limited — retrying in ~${Math.round(delaySecs / 60)}m`);
               return;
             }
 
@@ -338,15 +347,15 @@ jobs:
 
             // Response found but not clearly a review yet — wait one more cycle
             if (wait_count < 5) {
-              await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
               await enqueue('bot-coderabbit-check', {
                 pr_number, repo, attempt, trigger_time, wait_count: wait_count + 1, status_comment_id
               }, 60);
+              await updateStatus(`⏳ Waiting for CodeRabbit response... _(check ${wait_count + 1}/5)_`);
             } else {
-              await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
               await enqueue('bot-coderabbit-trigger', {
                 pr_number, repo, attempt: attempt + 1, status_comment_id
               }, 0);
+              await updateStatus(`🔄 Re-triggering CodeRabbit review _(attempt ${attempt + 1})_`);
             }
 
   # ── upstream check (scheduled) ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Living status comment** — on `@rickcedwhat-ai review`, the bot posts a status comment and edits it in place as the flow progresses rather than going silent after the 👍. The `status_comment_id` is threaded through every QStash payload so all downstream steps can edit the same comment.

  | Stage | Comment text |
  |---|---|
  | Triggered | `🔄 CodeRabbit review triggered` |
  | Waiting | `⏳ Waiting for CodeRabbit response... (check N/5)` |
  | Re-triggering | `🔄 Re-triggering CodeRabbit review (attempt N)` |
  | Rate limited | `⚠️ Rate limited — retrying in ~Xm` |
  | Complete, clean | `✅ No actionable comments — review complete` |
  | Complete, unresolved | `⚠️ Review complete — N unresolved thread(s) remain` |

- **180s first-check window** (was 90s) — CR typically takes 2-4 minutes; 90s was almost always too short, causing a spurious re-trigger on the first attempt.

## Test plan
- [ ] `@rickcedwhat-ai review` → status comment appears immediately
- [ ] Comment updates through waiting → complete stages
- [ ] Rate-limit path shows correct retry duration
- [ ] `status_comment_id` missing (e.g. coderabbit-retry flow) → `updateStatus` is a no-op, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Posts a persistent "🔄 CodeRabbit review triggered" status comment and threads its ID through retries so the same status comment is updated across cycles.
  * Longer retry interval for queued checks to allow more processing time.
  * Status messages now reflect waiting, rate-limit timing, in-progress checks, and final outcomes more clearly.

* **Bug Fixes**
  * Status update failures are logged as warnings and no longer break the retry flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->