### PR TITLE
fix(bot): exclude CR trigger acknowledgments from infinite loop

### DIFF
--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -225,7 +225,8 @@ jobs:
             });
             const crComments = allComments.filter(c =>
               c.user.login === 'coderabbitai[bot]' &&
-              (new Date(c.created_at) > triggerDate || new Date(c.updated_at) > triggerDate)
+              (new Date(c.created_at) > triggerDate || new Date(c.updated_at) > triggerDate) &&
+              !/Full review triggered/.test(c.body)  // exclude trigger acknowledgments — they are never actionable
             );
 
             if (crComments.length === 0) {


### PR DESCRIPTION
## Problem

The check was looping infinitely on any PR. Root cause:

CodeRabbit posts a short **"Full review triggered"** acknowledgment comment within seconds of receiving `@coderabbitai full review`. This comment's `created_at` is just after `trigger_time`, so it passed the filter — but it matched neither the rate-limit pattern nor the review pattern (too short, no Summary/walkthrough). It fell into the **"not clearly a review yet"** path, incrementing `wait_count` until a re-trigger, which generated a new acknowledgment, and so on forever.

## Fix

Exclude comments containing `"Full review triggered"` from `crComments`. They are CR's command acknowledgment, never actionable for review detection.

## Test plan
- [ ] `@rickcedwhat-ai review` → triggers CR, bot waits for actual review (not the acknowledgment)
- [ ] Loop stops when CR posts the real summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation workflow to refine how review bot comments are filtered and processed, improving the accuracy of actionable review responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->