### PR TITLE
feat(bot): auto-enqueue dependabot rebase when soak period expires

### DIFF
--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -134,21 +134,21 @@ jobs:
                 event_type: 'bot-dependabot-rebase',
                 client_payload: { pr_number: context.payload.pull_request.number, repo }
               });
-              const { execSync } = require('child_process');
-              const curlCmd =
-                `curl -s -o /tmp/qs-age.json -w "%{http_code}" -X POST ` +
-                `"https://qstash.upstash.io/v2/publish/${dispatchUrl}" ` +
-                `-H "Authorization: Bearer ${process.env.QSTASH_TOKEN}" ` +
-                `-H "Upstash-Delay: ${delaySecs}s" ` +
-                `-H "Upstash-Forward-Authorization: Bearer ${process.env.BOT_PAT}" ` +
-                `-H "Upstash-Forward-Content-Type: application/json" ` +
-                `-H "Content-Type: application/json" ` +
-                `-d '${qstashPayload.replace(/'/g, "'\\''")}'`;
-              const httpCode = parseInt(execSync(curlCmd).toString().trim(), 10);
-              if (httpCode >= 200 && httpCode < 300) {
+              const qstashRes = await fetch(`https://qstash.upstash.io/v2/publish/${dispatchUrl}`, {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
+                  'Upstash-Delay': `${delaySecs}s`,
+                  'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
+                  'Upstash-Forward-Content-Type': 'application/json',
+                  'Content-Type': 'application/json',
+                },
+                body: qstashPayload,
+              });
+              if (qstashRes.ok) {
                 core.info(`✓ Queued @dependabot rebase in ${delaySecs}s (fires ${rebaseAfterISO})`);
               } else {
-                core.warning(`QStash enqueue failed (HTTP ${httpCode}) — rebase will need to be triggered manually when soak period expires`);
+                core.warning(`QStash enqueue failed (HTTP ${qstashRes.status}) — rebase will need to be triggered manually when soak period expires`);
               }
 
               core.setFailed(

--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Verify npm packages are ≥ 7 days old
         uses: actions/github-script@v9
+        env:
+          QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT:      ${{ secrets.BOT_PAT }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -120,6 +123,32 @@ jobs:
                   issue_number: context.payload.pull_request.number,
                   body: commentBody,
                 });
+              }
+
+              // Enqueue a bot-dependabot-rebase via QStash to fire when the soak period expires.
+              // Delay = exact seconds until latestPublish + 7 days — rebase lands automatically.
+              const delaySecs = Math.ceil((latestPublish + MIN_AGE_MS - Date.now()) / 1000);
+              const repo = `${context.repo.owner}/${context.repo.repo}`;
+              const dispatchUrl = `https://api.github.com/repos/${repo}/dispatches`;
+              const qstashPayload = JSON.stringify({
+                event_type: 'bot-dependabot-rebase',
+                client_payload: { pr_number: context.payload.pull_request.number, repo }
+              });
+              const { execSync } = require('child_process');
+              const curlCmd =
+                `curl -s -o /tmp/qs-age.json -w "%{http_code}" -X POST ` +
+                `"https://qstash.upstash.io/v2/publish/${dispatchUrl}" ` +
+                `-H "Authorization: Bearer ${process.env.QSTASH_TOKEN}" ` +
+                `-H "Upstash-Delay: ${delaySecs}s" ` +
+                `-H "Upstash-Forward-Authorization: Bearer ${process.env.BOT_PAT}" ` +
+                `-H "Upstash-Forward-Content-Type: application/json" ` +
+                `-H "Content-Type: application/json" ` +
+                `-d '${qstashPayload.replace(/'/g, "'\\''")}'`;
+              const httpCode = parseInt(execSync(curlCmd).toString().trim(), 10);
+              if (httpCode >= 200 && httpCode < 300) {
+                core.info(`✓ Queued @dependabot rebase in ${delaySecs}s (fires ${rebaseAfterISO})`);
+              } else {
+                core.warning(`QStash enqueue failed (HTTP ${httpCode}) — rebase will need to be triggered manually when soak period expires`);
               }
 
               core.setFailed(


### PR DESCRIPTION
## Summary

- When `age-check` blocks a Dependabot PR for the 7-day npm soak period, it now immediately enqueues a `bot-dependabot-rebase` via QStash with a delay of `(latestPublish + 7d) - now` seconds
- When QStash fires, `bot-receiver` posts `@dependabot rebase` automatically — the PR will rebase itself right as the soak period expires, no manual trigger needed
- QStash failure degrades to a `core.warning` so the age-check failure message is unaffected and the PR is still blocked as normal

## How it works

```
age-check fails → posts soak comment + enqueues QStash(delay=Xs)
                                              ↓ X seconds later
                              bot-receiver fires → @dependabot rebase
                                              ↓
                              Dependabot rebases → age-check re-runs → passes → auto-merge
```

The delay is computed exactly: `Math.ceil((latestPublish + MIN_AGE_MS - Date.now()) / 1000)` — so the rebase fires at the first moment the package is old enough.

## Test plan

- [ ] Merge this, then observe PR #176 — when `@types/node@25.9.0` hits 7 days old (2026-05-25), QStash should fire and post `@dependabot rebase`
- [ ] Verify age-check still fails with the same error message when QStash is unreachable (secrets empty in fork PRs, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Dependabot automation: The system now automatically schedules dependency rebases when npm packages reach 7 days old. Previously, manual intervention was required; rebasing is now triggered programmatically upon age threshold compliance, with fallback notifications for edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->