### PR TITLE
fix(bot): detect CR nitpick review bodies as unresolved

### DIFF
--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -339,9 +339,13 @@ jobs:
                 }
               `, { owner, repo: repoName, number: pr_number });
 
+              // GraphQL author.login for the CR bot is 'coderabbitai' (no '[bot]' suffix),
+              // unlike the REST API which returns 'coderabbitai[bot]'. Use startsWith to
+              // handle both forms defensively.
+              const isCR = (login) => login?.startsWith('coderabbitai');
+
               const unresolvedCR = gqlResult.repository.pullRequest.reviewThreads.nodes.filter(
-                t => !t.isResolved &&
-                     t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
+                t => !t.isResolved && isCR(t.comments.nodes[0]?.author?.login)
               );
 
               // Nitpick comments are posted in a formal review body (state: COMMENTED)
@@ -349,7 +353,7 @@ jobs:
               // submitted after trigger_time as unresolved feedback.
               const triggerDate = new Date(trigger_time);
               const crNitpickReviews = gqlResult.repository.pullRequest.reviews.nodes.filter(
-                r => r.author?.login === 'coderabbitai[bot]' &&
+                r => isCR(r.author?.login) &&
                      r.state === 'COMMENTED' &&
                      new Date(r.submittedAt) > triggerDate &&
                      r.body.trim().length > 0

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -326,7 +326,7 @@ jobs:
                           }
                         }
                       }
-                      reviews(first: 50) {
+                      reviews(last: 50) {
                         nodes {
                           author { login }
                           state

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -311,7 +311,9 @@ jobs:
             );
             if (reviewComment) {
               // Check unresolved CodeRabbit threads via GraphQL (REST listReviewComments
-              // does not expose thread resolution state)
+              // does not expose thread resolution state).
+              // Also fetch formal reviews: CR posts nitpick-level content in the review
+              // body (state: COMMENTED) rather than as resolvable threads.
               const gqlResult = await github.graphql(`
                 query($owner: String!, $repo: String!, $number: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -324,19 +326,42 @@ jobs:
                           }
                         }
                       }
+                      reviews(first: 50) {
+                        nodes {
+                          author { login }
+                          state
+                          submittedAt
+                          body
+                        }
+                      }
                     }
                   }
                 }
               `, { owner, repo: repoName, number: pr_number });
+
               const unresolvedCR = gqlResult.repository.pullRequest.reviewThreads.nodes.filter(
                 t => !t.isResolved &&
                      t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
               );
 
-              if (unresolvedCR.length > 0) {
+              // Nitpick comments are posted in a formal review body (state: COMMENTED)
+              // rather than as inline threads. Treat any non-empty CR review body
+              // submitted after trigger_time as unresolved feedback.
+              const triggerDate = new Date(trigger_time);
+              const crNitpickReviews = gqlResult.repository.pullRequest.reviews.nodes.filter(
+                r => r.author?.login === 'coderabbitai[bot]' &&
+                     r.state === 'COMMENTED' &&
+                     new Date(r.submittedAt) > triggerDate &&
+                     r.body.trim().length > 0
+              );
+
+              if (unresolvedCR.length > 0 || crNitpickReviews.length > 0) {
+                const detail = unresolvedCR.length > 0
+                  ? `${unresolvedCR.length} unresolved thread${unresolvedCR.length > 1 ? 's' : ''}`
+                  : 'nitpick comments';
                 await swapLabel('coderabbit: unresolved');
                 await postStatus('failure', 'CodeRabbit has unresolved comments');
-                await updateStatus(`⚠️ Review complete — ${unresolvedCR.length} unresolved thread${unresolvedCR.length > 1 ? 's' : ''} remain`);
+                await updateStatus(`⚠️ Review complete — ${detail} remain`);
               } else {
                 await swapLabel('coderabbit: complete');
                 await postStatus('success', 'CodeRabbit review complete');

--- a/scripts/coderabbit-check-logic.mjs
+++ b/scripts/coderabbit-check-logic.mjs
@@ -1,0 +1,70 @@
+/**
+ * Pure decision logic for the coderabbit-check bot step.
+ *
+ * This module is imported by unit tests to verify correctness independently
+ * of the GitHub Actions runtime. The YAML keeps the logic inline, so keep
+ * this file in sync if the receiver changes.
+ *
+ * @typedef {{ isResolved: boolean, comments: { nodes: Array<{ author: { login: string } }> } }} ReviewThread
+ * @typedef {{ author: { login: string } | null, state: string, submittedAt: string, body: string }} Review
+ */
+
+/**
+ * Returns true for any CodeRabbit bot login.
+ * GraphQL returns 'coderabbitai'; REST returns 'coderabbitai[bot]'.
+ * Using startsWith handles both forms defensively.
+ *
+ * @param {string | null | undefined} login
+ * @returns {boolean}
+ */
+export function isCR(login) {
+  return login?.startsWith('coderabbitai') ?? false;
+}
+
+/**
+ * Filters review threads to find unresolved ones authored by CodeRabbit.
+ *
+ * @param {ReviewThread[]} threads
+ * @returns {ReviewThread[]}
+ */
+export function getUnresolvedCRThreads(threads) {
+  return threads.filter(
+    t => !t.isResolved && isCR(t.comments.nodes[0]?.author?.login)
+  );
+}
+
+/**
+ * Filters formal reviews to find CR nitpick reviews submitted after trigger_time.
+ * CR posts nitpick-level content in a COMMENTED review body rather than as
+ * resolvable inline threads.
+ *
+ * @param {Review[]} reviews
+ * @param {string} trigger_time  ISO-8601 timestamp
+ * @returns {Review[]}
+ */
+export function getCRNitpickReviews(reviews, trigger_time) {
+  const triggerDate = new Date(trigger_time);
+  return reviews.filter(
+    r => isCR(r.author?.login) &&
+         r.state === 'COMMENTED' &&
+         new Date(r.submittedAt) > triggerDate &&
+         r.body.trim().length > 0
+  );
+}
+
+/**
+ * Returns the outcome label and status detail string.
+ *
+ * @param {ReviewThread[]} unresolvedThreads
+ * @param {Review[]} nitpickReviews
+ * @returns {{ label: 'coderabbit: unresolved' | 'coderabbit: complete', detail: string }}
+ */
+export function getReviewOutcome(unresolvedThreads, nitpickReviews) {
+  if (unresolvedThreads.length > 0 || nitpickReviews.length > 0) {
+    const detail = unresolvedThreads.length > 0
+      ? `${unresolvedThreads.length} unresolved thread${unresolvedThreads.length > 1 ? 's' : ''}`
+      : 'nitpick comments';
+    return { label: 'coderabbit: unresolved', detail };
+  }
+  return { label: 'coderabbit: complete', detail: '' };
+}

--- a/tests/unit/coderabbit-check.test.ts
+++ b/tests/unit/coderabbit-check.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCR,
+  getUnresolvedCRThreads,
+  getCRNitpickReviews,
+  getReviewOutcome,
+} from '../../scripts/coderabbit-check-logic.mjs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function thread(login: string, isResolved: boolean) {
+  return { isResolved, comments: { nodes: [{ author: { login } }] } };
+}
+
+function review(login: string, state: string, submittedAt: string, body: string) {
+  return { author: { login }, state, submittedAt, body };
+}
+
+const TRIGGER = '2026-05-18T19:17:23Z';
+const AFTER   = '2026-05-18T19:19:53Z'; // 2m 30s after trigger
+const BEFORE  = '2026-05-18T19:15:00Z'; // 2m 23s before trigger
+
+// ---------------------------------------------------------------------------
+// isCR
+// ---------------------------------------------------------------------------
+
+describe('isCR', () => {
+  it('matches the GraphQL login format (no [bot] suffix)', () => {
+    expect(isCR('coderabbitai')).toBe(true);
+  });
+
+  it('matches the REST API login format (with [bot] suffix)', () => {
+    expect(isCR('coderabbitai[bot]')).toBe(true);
+  });
+
+  it('does not match unrelated bot logins', () => {
+    expect(isCR('dependabot[bot]')).toBe(false);
+    expect(isCR('github-actions[bot]')).toBe(false);
+    expect(isCR('rickcedwhat')).toBe(false);
+    expect(isCR('rickcedwhat-ai')).toBe(false);
+  });
+
+  it('handles null and undefined safely', () => {
+    expect(isCR(null)).toBe(false);
+    expect(isCR(undefined)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUnresolvedCRThreads
+// ---------------------------------------------------------------------------
+
+describe('getUnresolvedCRThreads', () => {
+  it('returns unresolved CR threads', () => {
+    const threads = [thread('coderabbitai', false)];
+    expect(getUnresolvedCRThreads(threads)).toHaveLength(1);
+  });
+
+  it('excludes resolved CR threads', () => {
+    const threads = [thread('coderabbitai', true)];
+    expect(getUnresolvedCRThreads(threads)).toHaveLength(0);
+  });
+
+  it('excludes unresolved threads from other authors', () => {
+    const threads = [thread('rickcedwhat', false)];
+    expect(getUnresolvedCRThreads(threads)).toHaveLength(0);
+  });
+
+  it('handles both REST and GraphQL CR login formats', () => {
+    const threads = [
+      thread('coderabbitai',       false), // GraphQL format
+      thread('coderabbitai[bot]',  false), // REST format
+    ];
+    expect(getUnresolvedCRThreads(threads)).toHaveLength(2);
+  });
+
+  it('returns only the unresolved CR threads from a mixed set', () => {
+    const threads = [
+      thread('coderabbitai', false),  // unresolved CR       → included
+      thread('coderabbitai', true),   // resolved CR         → excluded
+      thread('rickcedwhat',  false),  // unresolved non-CR   → excluded
+      thread('dependabot[bot]', false), // unresolved non-CR → excluded
+    ];
+    expect(getUnresolvedCRThreads(threads)).toHaveLength(1);
+  });
+
+  it('returns empty array for no threads', () => {
+    expect(getUnresolvedCRThreads([])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCRNitpickReviews
+// ---------------------------------------------------------------------------
+
+describe('getCRNitpickReviews', () => {
+  it('detects a COMMENTED CR review with body after trigger_time', () => {
+    const reviews = [review('coderabbitai', 'COMMENTED', AFTER, '🧹 Nitpick comments (1)')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(1);
+  });
+
+  it('excludes CR COMMENTED reviews submitted before trigger_time', () => {
+    const reviews = [review('coderabbitai', 'COMMENTED', BEFORE, '🧹 Nitpick comments (1)')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(0);
+  });
+
+  it('excludes CR COMMENTED reviews with empty body', () => {
+    const reviews = [review('coderabbitai', 'COMMENTED', AFTER, '   ')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(0);
+  });
+
+  it('excludes CR APPROVED reviews even with body after trigger_time', () => {
+    const reviews = [review('coderabbitai', 'APPROVED', AFTER, 'looks good')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(0);
+  });
+
+  it('excludes CR CHANGES_REQUESTED reviews (those create threads instead)', () => {
+    const reviews = [review('coderabbitai', 'CHANGES_REQUESTED', AFTER, 'must fix this')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(0);
+  });
+
+  it('excludes COMMENTED reviews from non-CR authors', () => {
+    const reviews = [review('rickcedwhat', 'COMMENTED', AFTER, 'some feedback')];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(0);
+  });
+
+  it('handles both REST and GraphQL CR login formats', () => {
+    const reviews = [
+      review('coderabbitai',      'COMMENTED', AFTER, 'nitpick 1'),
+      review('coderabbitai[bot]', 'COMMENTED', AFTER, 'nitpick 2'),
+    ];
+    expect(getCRNitpickReviews(reviews, TRIGGER)).toHaveLength(2);
+  });
+
+  it('returns empty array for no reviews', () => {
+    expect(getCRNitpickReviews([], TRIGGER)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getReviewOutcome
+// ---------------------------------------------------------------------------
+
+describe('getReviewOutcome', () => {
+  it('returns complete when there are no threads or nitpick reviews', () => {
+    const { label } = getReviewOutcome([], []);
+    expect(label).toBe('coderabbit: complete');
+  });
+
+  it('returns unresolved when there is 1 unresolved thread', () => {
+    const threads = [thread('coderabbitai', false)];
+    const { label, detail } = getReviewOutcome(threads, []);
+    expect(label).toBe('coderabbit: unresolved');
+    expect(detail).toBe('1 unresolved thread');
+  });
+
+  it('pluralises the thread count correctly', () => {
+    const threads = [thread('coderabbitai', false), thread('coderabbitai', false)];
+    const { detail } = getReviewOutcome(threads, []);
+    expect(detail).toBe('2 unresolved threads');
+  });
+
+  it('returns unresolved with "nitpick comments" when only nitpick reviews exist', () => {
+    const nitpick = [review('coderabbitai', 'COMMENTED', AFTER, '🧹 Nitpick comments (1)')];
+    const { label, detail } = getReviewOutcome([], nitpick);
+    expect(label).toBe('coderabbit: unresolved');
+    expect(detail).toBe('nitpick comments');
+  });
+
+  it('prefers thread count in detail when both threads and nitpick reviews exist', () => {
+    const threads = [thread('coderabbitai', false)];
+    const nitpick = [review('coderabbitai', 'COMMENTED', AFTER, 'nitpick')];
+    const { label, detail } = getReviewOutcome(threads, nitpick);
+    expect(label).toBe('coderabbit: unresolved');
+    expect(detail).toBe('1 unresolved thread');
+  });
+
+  it('complete result has empty detail string', () => {
+    const { label, detail } = getReviewOutcome([], []);
+    expect(label).toBe('coderabbit: complete');
+    expect(detail).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- CodeRabbit posts nitpick-level feedback in a **formal review body** (`state: COMMENTED`) rather than as resolvable inline threads — this is what appears as "🧹 Nitpick comments (1)" on a PR
- The existing `coderabbit-check` job only queried `reviewThreads` via GraphQL, so nitpick reviews were invisible and the PR got labelled `coderabbit: complete` incorrectly
- Extended the GraphQL query to also fetch `reviews`, and treat any non-empty CR review body with `state: COMMENTED` submitted after `trigger_time` as unresolved feedback

## What changed

```
reviewThreads(first: 100) { ... }      ← already there
reviews(first: 50) {                   ← new
  nodes { author state submittedAt body }
}
```

Any CR review where `state === 'COMMENTED'` and `body.trim().length > 0` and `submittedAt > trigger_time` → `coderabbit: unresolved`.

The status message distinguishes the two cases:
- `⚠️ Review complete — 2 unresolved threads remain` (existing)
- `⚠️ Review complete — nitpick comments remain` (new)

## Test plan

- [ ] Trigger `@rickcedwhat-ai review` on PR #178 after this merges — it should now label the PR `coderabbit: unresolved` instead of `coderabbit: complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of unresolved feedback by checking both inline threads and formal review comments (including nitpick/commented reviews) so PR status reflects actual review state.
  * PR label now toggles to "coderabbit: unresolved" or "coderabbit: complete" and status/summary messages show either unresolved thread counts or "nitpick comments" as appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->