### PR TITLE
docs: document beforeCellRead Y-scroll footgun (#46)

### DIFF
--- a/.agents/workflows/table-recon.md
+++ b/.agents/workflows/table-recon.md
@@ -124,7 +124,7 @@ navigation: {
 }
 ```
 
-**Do NOT use `beforeCellRead` or `columnOverrides` for scrolling.** Those are for reading special cell content (popovers, color indicators, etc). Navigation belongs in `navigation` primitives.
+**`beforeCellRead`** is for pre-read setup: waiting for lazy content, hovering to open popovers, or scrolling a column header into view on column-only (X-axis) virtualized grids. It **must not** be used for Y-axis scrolling — `scrollIntoViewIfNeeded` adjusts both axes and will unmount the current row on row-virtualized grids, producing empty reads. For 2D virtualized grids, use the `viewport` strategy instead. See [`docs/api/strategies.md` — beforeCellRead Hook](../../docs/api/strategies.md#beforecellread-hook) for details.
 
 ---
 

--- a/docs/api/strategies.md
+++ b/docs/api/strategies.md
@@ -260,6 +260,78 @@ The function receives `{ row, root, columnName, columnIndex, rowIndex?, page, co
 
 ---
 
+## beforeCellRead Hook
+
+`beforeCellRead` is called once per cell immediately before the cell value is read — in both `toJSON()` and any `columnOverrides.read` calls. Use it to handle cases where the cell content is not yet in a readable state when the row becomes visible.
+
+### Signature
+
+```typescript
+strategies: {
+  beforeCellRead: async ({ cell, columnName, columnIndex, row, page, root, getHeaderCell }) => {
+    // scroll, hover, wait — whatever the cell needs before its value can be read
+  }
+}
+```
+
+### When to use it
+
+| Use case | Safe? |
+|---|---|
+| Scroll a **column header** into view on a grid with **column-only** (X-axis) virtualization | ✅ Safe |
+| Hover a cell to trigger a tooltip / popover, then wait for it to render | ✅ Safe |
+| Wait for an async cell renderer to finish loading | ✅ Safe |
+| Call `scrollIntoViewIfNeeded()` on any element in a **row-virtualized** grid | ❌ Footgun |
+
+### Column-only horizontal virtualization
+
+For grids that keep all rows in the DOM but only render visible columns, scrolling the header into view forces the column to mount:
+
+```typescript
+strategies: {
+  beforeCellRead: async ({ columnName, getHeaderCell }) => {
+    const header = await getHeaderCell(columnName);
+    await header.scrollIntoViewIfNeeded();
+  }
+}
+```
+
+### Lazy-rendered cell content (popovers, tooltips)
+
+```typescript
+strategies: {
+  beforeCellRead: async ({ cell, page }) => {
+    await cell.hover();
+    await page.waitForSelector('.cell-tooltip', { state: 'visible' });
+  }
+}
+```
+
+### ⚠️ Y-scroll footgun on row-virtualized grids
+
+`scrollIntoViewIfNeeded` adjusts **both** scroll axes. On grids that recycle DOM nodes based on the Y scroll position (MUI DataGrid, AG Grid, `react-window`, etc.) calling it inside `beforeCellRead` will shift the viewport vertically, unmounting the row currently being read and silently returning stale or empty values for the rest of the row.
+
+**Do not use `beforeCellRead` for Y-axis scrolling.** Instead, configure the [`viewport` strategy](#viewport-strategy) — it drives explicit per-row and per-column scroll commands and understands the virtualization lifecycle.
+
+```typescript
+// ❌ Breaks row-virtualized grids — Y-scroll unmounts the current row mid-read
+strategies: {
+  beforeCellRead: async ({ cell }) => {
+    await cell.scrollIntoViewIfNeeded(); // scrolls Y → row recycled → empty values
+  }
+}
+
+// ✅ Correct approach for 2D virtualized grids
+strategies: {
+  viewport: Strategies.Viewport.dataAttribute({
+    rowAttribute: 'data-rowindex',
+    columnAttribute: 'data-colindex',
+  })
+}
+```
+
+---
+
 ## Viewport Strategy
 
 Viewport strategies help with 2D virtualized grids where rows and columns are both mounted only when visible. They let the cell-reading engine detect what is currently in the DOM and jump directly to the target row or column when scrolling one axis causes the other axis to unmount.

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,16 +41,45 @@ export type GetCellLocatorFn = (args: {
 }) => Locator;
 
 /**
- * Hook called before each cell value is read in toJSON (and columnOverrides.read).
- * Use this to scroll off-screen columns into view in horizontally virtualized tables,
- * wait for lazy-rendered content, or perform any pre-read setup.
+ * Hook called before each cell value is read in `toJSON` (and `columnOverrides.read`).
+ *
+ * Use this to scroll off-screen columns into view in **horizontally** virtualized tables,
+ * wait for lazy-rendered content (popovers, tooltips, async cell renderers), or perform
+ * any other pre-read setup that doesn't involve Y-axis scrolling.
+ *
+ * ---
+ *
+ * **⚠️ Y-scroll footgun — do NOT call `scrollIntoViewIfNeeded()` on row-virtualized grids.**
+ *
+ * `scrollIntoViewIfNeeded` adjusts *both* scroll axes. On grids that recycle DOM nodes
+ * based on the Y position (MUI DataGrid, AG Grid, react-window, etc.) calling it will
+ * shift the viewport vertically, unmounting the row you are currently reading and
+ * silently returning stale or empty cell values for the remainder of the row.
+ *
+ * Safe uses:
+ * - Column-only (X-axis) virtualization where rows are always in the DOM.
+ * - Calling `scrollIntoViewIfNeeded` on the **header cell** only, when that header is
+ *   guaranteed not to trigger a Y-scroll (e.g. sticky header grids).
+ *
+ * For grids with **both** row and column virtualization, use the `viewport` strategy
+ * instead — it drives explicit `scrollToRow` / `scrollToColumn` calls and is aware of
+ * the virtualization lifecycle.
  *
  * @example
- * // Scroll the column header into view to trigger horizontal virtualization render
+ * // Safe: column-only horizontal virtualization (rows always in DOM)
  * strategies: {
  *   beforeCellRead: async ({ columnName, getHeaderCell }) => {
  *     const header = await getHeaderCell(columnName);
- *     await header.scrollIntoViewIfNeeded();
+ *     await header.scrollIntoViewIfNeeded(); // only scrolls X — rows stay mounted
+ *   }
+ * }
+ *
+ * @example
+ * // Safe: wait for a lazy-rendered popover/tooltip before reading its text
+ * strategies: {
+ *   beforeCellRead: async ({ cell }) => {
+ *     await cell.hover();
+ *     await cell.page().waitForSelector('.cell-tooltip', { state: 'visible' });
  *   }
  * }
  */


### PR DESCRIPTION
## Summary

- Adds a new `## beforeCellRead Hook` section to `docs/api/strategies.md` covering safe uses (column-only X-scroll, lazy content/popovers), the Y-scroll footgun (row-virtualized grids where `scrollIntoViewIfNeeded` unmounts the current row mid-read), and the correct alternative (`viewport` strategy)
- Updates `BeforeCellReadFn` JSDoc in `src/types.ts` with an inline ⚠️ warning, clearer safe/unsafe distinctions, and two concrete `@example` blocks (X-only scroll, tooltip hover)
- Tightens the `table-recon.md` workflow note — corrects the blanket "don't use for scrolling" statement to the accurate nuance and cross-links to the new docs section

## Test plan

- [ ] `pnpm run build` passes (no TypeScript errors from JSDoc changes)
- [ ] Review `docs/api/strategies.md` — beforeCellRead section renders correctly with table, code blocks, and callout
- [ ] Verify `src/types.ts` JSDoc renders in IDE hover

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for the `beforeCellRead` strategy hook with detailed usage examples
  * Added comprehensive guidance and warnings regarding proper usage with virtualized tables to prevent cell-reading issues
  * Clarified best practices for both horizontal and 2D virtualization scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->