### PR TITLE
fix(bot): handle CR review-skipped and respect manual label overrides

### DIFF
--- a/.github/workflows/bot-pr-hq.yml
+++ b/.github/workflows/bot-pr-hq.yml
@@ -1,8 +1,8 @@
 name: Bot — PR HQ Comment
 
-# Posts and maintains the "Bot HQ" comment on every non-Dependabot PR.
+# Posts and maintains the "Bot HQ" comment on every PR (including Dependabot).
 # The HQ comment is the central status surface for each PR:
-#   - Issue link check (updates live when the PR body is edited)
+#   - Issue link check (updates live when the PR body is edited; N/A for Dependabot)
 #   - CodeRabbit review status + one-click trigger checkbox
 #
 # Additional sections can be appended between the section markers in future.
@@ -15,8 +15,6 @@ jobs:
   upsert-hq:
     name: Upsert HQ comment
     runs-on: ubuntu-latest
-    # Skip Dependabot PRs — they never have issue links and don't use CodeRabbit
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Upsert Bot HQ comment
         uses: actions/github-script@v9
@@ -26,6 +24,7 @@ jobs:
             const { owner, repo } = context.repo;
             const pr_number = context.payload.pull_request.number;
             const prBody = context.payload.pull_request.body || '';
+            const isDependabot = context.payload.pull_request.user.login === 'dependabot[bot]';
 
             // ── helpers ──────────────────────────────────────────────────────
 
@@ -40,6 +39,9 @@ jobs:
             }
 
             function buildIssueLinkContent(body) {
+              if (isDependabot) {
+                return '### 🔗 Issue Link\n_N/A — automated dependency update_';
+              }
               if (hasIssueLink(body)) {
                 const refs = extractIssueRefs(body) ?? 'an issue';
                 return `### 🔗 Issue Link\n✅ Linked to ${refs}`;

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -74,6 +74,20 @@ jobs:
               }
             }
 
+            // Check terminal labels FIRST — before the retry-limit branch, so a
+            // queued trigger arriving after attempt > 10 can never overwrite a
+            // manually-set complete/unresolved label.
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo: repoName, issue_number: pr_number
+            });
+            const isTerminal = labels.some(l =>
+              l.name === 'coderabbit: complete' || l.name === 'coderabbit: unresolved'
+            );
+            if (isTerminal) {
+              core.setOutput('stop', 'true');
+              return;
+            }
+
             if (attempt > 10) {
               await github.rest.issues.createComment({
                 owner, repo: repoName, issue_number: pr_number,
@@ -81,9 +95,6 @@ jobs:
               });
               await updateHQCRSection(hq_comment_id, '❌ Review failed after 10 attempts — please trigger manually');
               // Swap label back to not started
-              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                owner, repo: repoName, issue_number: pr_number
-              });
               for (const l of labels.filter(l => l.name.startsWith('coderabbit:'))) {
                 try {
                   await github.rest.issues.removeLabel({
@@ -214,8 +225,11 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
-            const { pr_number, repo, attempt, trigger_time, wait_count = 0, hq_comment_id } =
-              context.payload.client_payload;
+            const {
+              pr_number, repo, attempt, trigger_time,
+              wait_count = 0, submission_wait_count = 0,
+              hq_comment_id
+            } = context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
 
             // Helper: swap label
@@ -420,6 +434,26 @@ jobs:
               return;
             }
 
+            // Check for "review skipped" (e.g. lock-file-only PR, all files excluded by path filters)
+            const skippedComment = crComments.find(
+              c => /review was skipped|Review skipped/i.test(c.body)
+            );
+            if (skippedComment) {
+              // A skipped review has no new findings — but if the PR already has
+              // unresolved threads from a previous run, preserve that state.
+              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                owner, repo: repoName, issue_number: pr_number
+              });
+              const alreadyUnresolved = currentLabels.some(l => l.name === 'coderabbit: unresolved');
+              if (!alreadyUnresolved) {
+                await swapLabel('coderabbit: complete');
+                await postStatus('success', 'CodeRabbit review skipped — no reviewable files');
+                await updateStatus('✅ Review skipped — no reviewable files (e.g. lock file only)');
+              }
+              await drainQueue();
+              return;
+            }
+
             // Check for review completion (Summary or walkthrough sections)
             const reviewComment = crComments.find(
               c => /## Summary|walkthrough/i.test(c.body) && c.body.length > 500
@@ -455,6 +489,24 @@ jobs:
               `, { owner, repo: repoName, number: pr_number });
 
               const pr = gqlResult.repository.pullRequest;
+
+              // Gate: CR updates its walkthrough issue comment first, then submits
+              // the formal PR review (with inline threads) ~30s later. If no formal
+              // review has landed yet, wait one more 60s cycle to avoid racing past
+              // unresolved threads. Allow up to 3 extra waits (~3 min total buffer).
+              const crFormalReview = pr.reviews.nodes.some(
+                r => isCR(r.author?.login) && new Date(r.submittedAt) > triggerDate
+              );
+              if (!crFormalReview && submission_wait_count < 3) {
+                await enqueue('bot-coderabbit-check', {
+                  pr_number, repo, attempt, trigger_time,
+                  wait_count, submission_wait_count: submission_wait_count + 1,
+                  hq_comment_id
+                }, 60);
+                await updateStatus(`⏳ Waiting for CodeRabbit review submission... _(check ${submission_wait_count + 1}/3)_`);
+                return;
+              }
+
               const unresolvedCR = pr.reviewThreads.nodes.filter(
                 t => !t.isResolved && isCR(t.comments.nodes[0]?.author?.login)
               );


### PR DESCRIPTION
## Problem

Three bugs surfaced on PR #176 (lock-file-only Dependabot PR):

**1. Bot HQ comment not created for Dependabot PRs**
The workflow had an explicit `if: user.login != 'dependabot[bot]'` guard, so Dependabot PRs never got the HQ comment with the CR checkbox.

**2. "Review skipped" not recognized**
When all changed files are excluded by CodeRabbit path filters (e.g. `pnpm-lock.yaml`), CR posts a "Review skipped" comment instead of a walkthrough/summary. The bot only matched `## Summary|walkthrough`, so it never saw a terminal state — exhausted all 10 retry attempts spamming \`@coderabbitai full review\`.

**3. Manual label override ignored**
After manually setting the label to \`coderabbit: complete\`, the next already-queued \`bot-coderabbit-trigger\` fired, saw \`attempt <= 10\`, and overwrote the label back to \`coderabbit: waiting\`.

## Fix

- `bot-pr-hq.yml`: remove the Dependabot guard; show "N/A — automated dependency update" in the issue-link section instead of the warning
- `bot-receiver.yml` (`coderabbit-check`): detect `/review was skipped/i` comment and treat it as complete
- `bot-receiver.yml` (`check-attempt`): bail out if the current CR label is already `complete` or `unresolved`

## Test plan
- [ ] Open/sync a Dependabot PR → Bot HQ comment with CR checkbox should appear
- [ ] Check the CR box on a lock-file-only PR → should detect skip and mark complete after first check cycle
- [ ] Manually set label to `coderabbit: complete` mid-flight → next trigger should not overwrite it

Closes the spam on #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Better handling of automated dependency (Dependabot) pull requests in review workflows, including tailored issue-link messaging.
  * Preserve terminal review label state to avoid overwriting prior outcomes.
  * Detect and mark skipped/no-op reviews as complete, post success status, and update PR summary.
  * Add short wait/retry gating to avoid race conditions when detecting review completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->