### PR TITLE
fix(ci): deduplicate QStash rebase dispatch per PR

### DIFF
--- a/.github/workflows/dependabot-age-check.yml
+++ b/.github/workflows/dependabot-age-check.yml
@@ -129,16 +129,18 @@ jobs:
               // Delay = exact seconds until latestPublish + 7 days — rebase lands automatically.
               const delaySecs = Math.ceil((latestPublish + MIN_AGE_MS - Date.now()) / 1000);
               const repo = `${context.repo.owner}/${context.repo.repo}`;
+              const prNumber = context.payload.pull_request.number;
               const dispatchUrl = `https://api.github.com/repos/${repo}/dispatches`;
               const qstashPayload = JSON.stringify({
                 event_type: 'bot-dependabot-rebase',
-                client_payload: { pr_number: context.payload.pull_request.number, repo }
+                client_payload: { pr_number: prNumber, repo }
               });
               const qstashRes = await fetch(`https://qstash.upstash.io/v2/publish/${dispatchUrl}`, {
                 method: 'POST',
                 headers: {
                   'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
                   'Upstash-Delay': `${delaySecs}s`,
+                  'Upstash-Deduplication-Id': `dependabot-rebase-${repo}-pr-${prNumber}`,
                   'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
                   'Upstash-Forward-Content-Type': 'application/json',
                   'Content-Type': 'application/json',


### PR DESCRIPTION
## Problem

The age-check workflow triggers on every `synchronize` event. When Dependabot pushes multiple commits to a PR branch, the age-check runs once per push and enqueues a separate QStash job each time — all with identical delays (since they're all calculated from the same `latestPublish + 7 days`). This caused PR #176 to receive 3 `@dependabot rebase` comments within 2 seconds.

## Fix

Add `Upstash-Deduplication-Id: dependabot-rebase-{repo}-pr-{prNumber}` to the QStash publish call. QStash deduplicates messages with the same ID within a 24-hour window, so only the first enqueue per PR fires — subsequent ones for the same PR are silently dropped.

## Test plan
- [ ] Verify a Dependabot PR with multiple synchronize events only produces one `@dependabot rebase` comment at soak expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the efficiency of automated dependency management processes by preventing duplicate rebase requests from being queued.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->