### PR TITLE
fix(bot): clarify CR review is required to merge in HQ comment

### DIFF
--- a/.github/workflows/bot-pr-hq.yml
+++ b/.github/workflows/bot-pr-hq.yml
@@ -104,7 +104,7 @@ jobs:
                 '### 🔍 CodeRabbit Review',
                 '- [ ] Request review',
                 '',
-                '> ⚠️ New commits pushed — check the box to request a fresh review.',
+                '> ⚠️ New commits pushed — **check the box above to request a fresh review. This PR cannot be merged until a CodeRabbit review is complete.**',
               ].join('\n');
               const updatedBody = updateHQSection(existing.body, 'coderabbit', pendingContent);
               if (updatedBody !== existing.body) {


### PR DESCRIPTION
## Summary
- Updates the "new commits pushed" message in the Bot HQ comment to make it explicit that checking the box is a merge requirement, not just a suggestion

Before: `⚠️ New commits pushed — check the box to request a fresh review.`
After: `⚠️ New commits pushed — **check the box above to request a fresh review. This PR cannot be merged until a CodeRabbit review is complete.**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the pull request review notification messaging to provide clearer instructions when new commits are pushed, including a reminder to request a fresh code review and clarification that merging requires a completed review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->