### PR TITLE
fix(ci): fix mutation testing — pnpm, weekly schedule, auto-issue on failure

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -2,13 +2,15 @@ name: Mutation Testing
 
 on:
   schedule:
-    # Run at 02:00 UTC every day
-    - cron: '0 2 * * *'
-  workflow_dispatch: # Allow manual triggering
+    # Run at 02:00 UTC every Monday
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
 
 jobs:
   mutate:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -43,8 +45,47 @@ jobs:
 
       - name: Upload Mutation Report
         uses: actions/upload-artifact@v7
-        if: always() # Upload report even if tests fail
+        if: always()
         with:
           name: stryker-report
           path: reports/mutation/
-          retention-days: 7
+          retention-days: 30
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = 'Mutation testing failed';
+
+            // Don't open a duplicate if one is already open
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner, repo,
+              state: 'open',
+              labels: 'mutation-testing',
+            });
+            if (issues.some(i => i.title === title)) {
+              core.info('Open mutation-testing issue already exists — skipping');
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner, repo,
+              title,
+              labels: ['mutation-testing'],
+              body: [
+                '## Mutation testing is broken',
+                '',
+                `The weekly Stryker run failed. [View run](${runUrl})`,
+                '',
+                'Common causes:',
+                '- Stryker or vitest-runner version incompatibility after a dependency bump',
+                '- Plugin resolution failure (check `stryker.config.json` `packageManager`)',
+                '- A mutant caused a test suite hang (check for timeout errors in the log)',
+                '',
+                'Download the `stryker-report` artifact from the run for details.',
+              ].join('\n'),
+            });

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -5,7 +5,7 @@
             "@stryker-mutator/vitest-runner"
         ]
     },
-    "packageManager": "npm",
+    "packageManager": "pnpm",
     "reporters": [
         "html",
         "clear-text",


### PR DESCRIPTION
## Summary
- **`stryker.config.json`**: `packageManager: npm` → `pnpm` — this was the root cause of the `Cannot find TestRunner plugin "vitest"` error. Stryker couldn't resolve the vitest-runner plugin because it was using npm resolution in a pnpm project.
- **`mutation-testing.yml`**: Schedule changed from daily (`0 2 * * *`) to weekly (`0 2 * * 1`, Monday 02:00 UTC)
- **`mutation-testing.yml`**: Added `open-issue-on-failure` step — if the run fails, it opens a `mutation-testing`-labelled issue with a link to the run and common causes. Deduplicates: won't open a second issue if one with that title is already open.

## Response when an issue is opened
The issue means one of: Stryker/vitest-runner version mismatch after a dep bump, plugin config problem, or a mutant hanging the test suite. Check the run log and `stryker-report` artifact, fix the root cause, then close the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Mutation testing workflow now runs weekly on Mondays at 02:00 UTC instead of daily.
  * Artifact retention for mutation testing reports increased to 30 days.
  * Automated GitHub issue creation added for mutation testing failures, with duplicate-checking to avoid repeats and a link to the failed run.
  * Project package manager switched from npm to pnpm.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->