### PR TITLE
fix(bot): anchor CR rate-limit delay to comment creation time

### DIFF
--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -498,6 +498,8 @@ jobs:
 
               const pr = gqlResult.repository.pullRequest;
 
+              const triggerDate = new Date(trigger_time);
+
               // Gate: CR updates its walkthrough issue comment first, then submits
               // the formal PR review (with inline threads) ~30s later. If no formal
               // review has landed yet, wait one more 60s cycle to avoid racing past
@@ -519,7 +521,6 @@ jobs:
                 t => !t.isResolved && isCR(t.comments.nodes[0]?.author?.login)
               );
 
-              const triggerDate = new Date(trigger_time);
               const crNitpickReviews = pr.reviews.nodes.filter(
                 r => isCR(r.author?.login) &&
                      r.state === 'COMMENTED' &&

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -28,6 +28,27 @@ jobs:
           script: |
             const { pr_number, repo } = context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
+
+            // Guard: only fire if still rate-limited (duplicate QStash messages skip)
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo: repoName, issue_number: pr_number
+            });
+            const labelNames = labels.map(l => l.name);
+            if (!labelNames.includes('coderabbit: rate-limited')) {
+              core.info(`PR #${pr_number} is no longer rate-limited (label: ${labelNames.join(', ')}), skipping retry`);
+              return;
+            }
+
+            // Swap label first so any subsequent duplicate messages skip
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo: repoName, issue_number: pr_number, name: 'coderabbit: rate-limited'
+              });
+            } catch {}
+            await github.rest.issues.addLabels({
+              owner, repo: repoName, issue_number: pr_number, labels: ['coderabbit: waiting']
+            });
+
             await github.rest.issues.createComment({
               owner,
               repo: repoName,

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -416,16 +416,24 @@ jobs:
               await swapLabel('coderabbit: rate-limited');
               await postStatus('pending', 'CodeRabbit rate-limited — retry queued');
 
-              // Parse duration from message
-              const durationMatch = rateLimitComment.body.match(/(\d+)\s*(minute|min|hour)/i);
-              let delaySecs = 30 * 60; // default 30 minutes
-              if (durationMatch) {
-                const val = parseInt(durationMatch[1]);
-                const unit = durationMatch[2].toLowerCase();
-                delaySecs = unit.startsWith('hour') ? val * 3600 : val * 60;
-              }
-              // Add 1 minute buffer
-              delaySecs += 60;
+              // Parse hours/minutes/seconds from the rate-limit comment body,
+              // then anchor to when CR *posted* the comment so elapsed processing
+              // time doesn't inflate the delay.
+              const body = rateLimitComment.body;
+              const hMatch = body.match(/(\d+)\s*hour/i);
+              const mMatch = body.match(/(\d+)\s*min/i);
+              const sMatch = body.match(/(\d+)\s*sec/i);
+              let durationMs =
+                (hMatch ? parseInt(hMatch[1]) * 3600000 : 0) +
+                (mMatch ? parseInt(mMatch[1]) * 60000   : 0) +
+                (sMatch ? parseInt(sMatch[1]) * 1000    : 0);
+              if (!durationMs) durationMs = 30 * 60 * 1000; // fallback 30 min
+
+              const commentedAt = new Date(rateLimitComment.created_at).getTime();
+              const availableAt = commentedAt + durationMs;
+              // 60s buffer after CR becomes available; floor at 30s in case we're
+              // already past the window when this handler runs.
+              const delaySecs = Math.max(30, Math.ceil((availableAt - Date.now()) / 1000)) + 60;
 
               await enqueue('bot-coderabbit-trigger', {
                 pr_number, repo, attempt: attempt + 1, hq_comment_id

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -451,7 +451,11 @@ jobs:
               if (!durationMs) durationMs = 30 * 60 * 1000; // fallback 30 min
 
               const commentedAt = new Date(rateLimitComment.created_at).getTime();
-              const availableAt = commentedAt + durationMs;
+              if (isNaN(commentedAt)) {
+                core.warning('Rate-limit comment missing valid created_at — falling back to 30 min from now');
+                durationMs = 30 * 60 * 1000;
+              }
+              const availableAt = (isNaN(commentedAt) ? Date.now() : commentedAt) + durationMs;
               // 60s buffer after CR becomes available; floor at 30s in case we're
               // already past the window when this handler runs.
               const delaySecs = Math.max(30, Math.ceil((availableAt - Date.now()) / 1000)) + 60;


### PR DESCRIPTION
## Problem
The rate-limit delay was parsed from the comment text and applied from the moment the bot-receiver ran — not from when CR actually posted the comment. Any lag between CR posting ("available in 26m 39s") and the handler running inflated the real wait. Seconds were also silently dropped (the regex only captured the first number+unit).

**Example from PR #186:** CR posted at ~0:58 saying "26m 39s". Bot processed it at ~1:00. QStash was scheduled for 27m from 1:00 → fires at 1:27. CR was actually available at 1:24:39. Wasted ~2.5 min.

## Fix
- Parse hours + minutes + seconds from the rate-limit comment body
- Anchor to `rateLimitComment.created_at` so elapsed processing time is subtracted automatically: `delaySecs = (commentedAt + durationMs - Date.now()) / 1000`
- Floor at 30s in case the rate limit already expired by the time the handler runs
- 60s buffer still applied on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limit handling to parse additional time duration formats and calculate retry delays more accurately.
  * Enhanced retry logic with minimum delay enforcement and buffering for more reliable bot operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->