### PR TITLE
docs: embed LabQueryBuilder in Getting Started

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -42,6 +42,14 @@ That means your test can say “the row where `Name` is `Airi Satou`, then the `
 | Read a value from every row | `await table.map(({ row }) => ...)` |
 | Click, fill, or assert every row in order | `await table.forEach(async ({ row }) => ...)` |
 
+## Try It: Live Filter Builder
+
+The editor below mirrors what you write in a real test. Type a column name and a value — the table on the right highlights the matching row instantly. Add more key/value pairs to narrow results further.
+
+Misspell a column name (try `Naem` instead of `Name`) to see the same fuzzy error that the library throws at runtime, with suggestions shown inline.
+
+<LabQueryBuilder />
+
 ### Current Page
 
 Use `getRow()` when the row is already visible. Because it is synchronous, call `init()` first.


### PR DESCRIPTION
## Summary

- Adds a new **"Try It: Live Filter Builder"** section to `docs/guide/getting-started.md`, placed after the "Which Method Should I Use?" reference table
- Embeds `<LabQueryBuilder />` directly in the guide page with a brief prose intro explaining how to interact with it (type a column + value, watch the table respond; misspell a column to see the fuzzy error)
- No sidebar or nav config changes needed — `getting-started.md` is already in the nav and `LabQueryBuilder` is already globally registered in `docs/.vitepress/theme/index.ts`

## Component changes

No changes to `LabQueryBuilder.vue` — the component was already production-ready. The prose in the new section surfaces the typo/fuzzy-suggestion feature explicitly, which was not called out anywhere in the main docs before.

## Test plan

- [ ] Run `npm run docs:dev` and navigate to `/guide/getting-started`
- [ ] Verify the "Try It: Live Filter Builder" section renders below the "Which Method Should I Use?" table
- [ ] Type `Name` / `Airi Satou` in the filter inputs — confirm the row highlights green and the result badge shows "1 match"
- [ ] Type `Naem` (misspelled) as a column — confirm the red error box appears with fuzzy suggestions
- [ ] Add a second filter pair — confirm multi-filter AND logic narrows results correctly
- [ ] Verify the `getCell()` row below the filter editor reflects the selected column value
- [ ] Check mobile layout (below 860px) — confirm the component stacks to a single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Getting Started guide with a new interactive section demonstrating row filtering using column/value pairs, including fuzzy error handling with suggestions for misspelled column names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->