### PR TITLE
docs: embed LabBeforeAfterV2 column shuffle demo in Table Anatomy

### DIFF
--- a/docs/concepts/table-anatomy.md
+++ b/docs/concepts/table-anatomy.md
@@ -34,7 +34,7 @@ The selector model above keeps your test code stable across layout changes — b
 
 Real tables get reshuffled all the time. A product team adds a "Priority" column to the front. A user drags "Status" to the right. An A/B test swaps two columns for half of your traffic. Any of those changes silently breaks locators that refer to columns by their numeric position (`.nth(2)`, `td:eq(3)`, etc.).
 
-Smart Table resolves cells by **header name**, not position. The column map is built once at `init()` from the live `<th>` elements, so the mapping always reflects the actual layout — even when it changes between test runs.
+Smart Table resolves cells by **header name**, not position. The column map is built lazily on first use from the live header elements resolved by your `headerSelector` (or header strategy), then cached in memory. Subsequent calls return the cached map — it is only rebuilt when `revalidate()` or `remapHeaders()` clears the cache, so the mapping always reflects the layout at the time of the last (re)initialization.
 
 ### See it in action
 

--- a/docs/concepts/table-anatomy.md
+++ b/docs/concepts/table-anatomy.md
@@ -27,3 +27,24 @@ await expect(row.getCell('Office')).toHaveText('Tokyo');
 ```
 
 For messy headers, see [Header Mapping](/concepts/header-mapping). For paginated tables, see [Pagination Strategies](/concepts/pagination-strategies).
+
+## Why Column Order Must Not Matter
+
+The selector model above keeps your test code stable across layout changes — but there is a subtler threat: **column reordering**.
+
+Real tables get reshuffled all the time. A product team adds a "Priority" column to the front. A user drags "Status" to the right. An A/B test swaps two columns for half of your traffic. Any of those changes silently breaks locators that refer to columns by their numeric position (`.nth(2)`, `td:eq(3)`, etc.).
+
+Smart Table resolves cells by **header name**, not position. The column map is built once at `init()` from the live `<th>` elements, so the mapping always reflects the actual layout — even when it changes between test runs.
+
+### See it in action
+
+The demo below drives the same five questions against the same table data. Click **Shuffle columns** and watch what happens to the two approaches:
+
+- **Brittle (fixed indices):** the locator code is frozen — column numbers baked in at write time. After a shuffle it reads from whichever cell happens to land in that slot.
+- **Smart Table:** resolves column positions at runtime from the header row. The answer is always correct, regardless of column order.
+
+<LabBeforeAfterV2 />
+
+The underlying employee data never changes — only column positions do. Yet one approach returns wrong answers the moment the table is reshuffled, while the other stays correct every time.
+
+This is the core guarantee that `headerSelector` + `cellSelector` together provide: your test assertions are tied to **meaning** (the column name), not to **position** (the nth cell in a row).


### PR DESCRIPTION
## Summary

- Adds a **"Why Column Order Must Not Matter"** section to `docs/concepts/table-anatomy.md` after the existing `<TableAnatomy />` component block
- Explains the column-reordering failure mode with concrete real-world scenarios (product teams adding columns, A/B tests, user drag-and-drop)
- Embeds `<LabBeforeAfterV2 />` — the interactive column shuffle demo — so readers can immediately experience brittle index-based locators breaking vs. Smart Table staying correct
- Closes with a clear takeaway tying `headerSelector` + `cellSelector` back to the "meaning not position" principle

## Test plan

- [ ] `pnpm run docs:dev` — navigate to `/concepts/table-anatomy`, verify the new section renders and `<LabBeforeAfterV2 />` loads
- [ ] Click **Shuffle columns** — brittle panel should show wrong/empty answers; Smart Table panel should stay correct
- [ ] Click **Reset** — both panels return to correct state
- [ ] Switch questions in the dropdown — results update for all five questions
- [ ] Responsive check: section readable on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance explaining how table assertions remain resilient when columns are reordered, including an interactive demonstration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->