### PR TITLE
docs: embed LabPaginationSandbox in Pagination Strategies page

### DIFF
--- a/docs/concepts/pagination-strategies.md
+++ b/docs/concepts/pagination-strategies.md
@@ -23,3 +23,19 @@ This page shows common pagination shapes and the strategy primitive that usually
 - Infinite scroll and load-more UIs still use the pagination strategy slot; the strategy just scrolls or loads instead of clicking a numbered pagination component.
 
 Each primitive should return `true` when movement happened and `false` when there is nowhere else to go. For exact signatures, see [Pagination Strategies](/api/strategies#pagination-strategies).
+
+---
+
+## Try It — Pagination Config Builder
+
+The sandbox below lets you explore how different pagination setups translate directly into library config. Switch between pagination types, toggle optional selectors on and off, and watch the generated config update live. Use the plan builder to pick a target page and see exactly which primitives Smart Table would call to get there — then step through or run them all at once against the mock table.
+
+<LabPaginationSandbox />
+
+### What to notice
+
+- **Toggling `first` / `last` off** removes those lines from the config and changes the plan: without `goToLast`, wrap-around paths are unavailable; without `goToFirst`, backward navigation must rely on `previous` or `previousBulk` alone.
+- **`nextBulk` / `previousBulk` trade fewer clicks for a coarser granularity.** Enable them to see the planner skip entire decades of pages instead of stepping one at a time — but note that `nextBulkPages` must match the actual number of pages your UI advances per click.
+- **`numberOfPages` unlocks wrap-around.** When it is enabled and `last` is present, the planner can jump to the end and work backwards — often the shortest path to a high-numbered page.
+- **Load More and Infinite Scroll are forward-only.** Once content is loaded it stays in the DOM; the library only needs to advance, never retreat. That is why `goToFirst` and `goToPrevious` do not appear in those configs.
+- **Every config is minimal by design.** You only describe the controls that actually exist in your UI. Anything you omit is simply not used by Smart Table during a search.


### PR DESCRIPTION
## Summary

- Adds a **\"Try It — Pagination Config Builder\"** section to `docs/concepts/pagination-strategies.md`, positioned after the existing `<PaginationStrategies />` anatomy diagram
- Embeds `<LabPaginationSandbox />` (globally registered, no import needed) with a short prose intro explaining what the sandbox does
- Includes a five-point \"What to notice\" list that maps sandbox interactions — toggling selectors, switching pagination types, enabling `numberOfPages`, choosing Load More / Infinite Scroll — to concrete config and usage decisions

## Test plan

- [ ] Run `npm run docs:dev` and navigate to `/concepts/pagination-strategies`
- [ ] Verify the new section renders below the anatomy diagram with the sandbox interactive and functional
- [ ] Toggle selectors on/off — confirm config lines appear/disappear and the plan adapts
- [ ] Switch between Page Buttons, Load More, and Infinite Scroll — confirm each shows the correct generated config
- [ ] Use the plan builder: enter a target page, click Plan, then Step / Run all — confirm the mock table updates
- [ ] Check mobile layout (≤760 px) — sandbox should stack to a single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Pagination Strategies documentation with an interactive configuration builder that demonstrates how different pagination UI setups map to library configurations and shows how toggling pagination options affects available features including wrap-around, bulk-step behavior, and load-more/infinite-scroll patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->