### PR TITLE
docs: embed findRow debuggers in Table Methods API page

### DIFF
--- a/docs/api/table-methods.md
+++ b/docs/api/table-methods.md
@@ -94,14 +94,14 @@ getRow(
 const row = table.getRow({ Name: 'John' });
 
 // ✅ Multi-column filter (must match ALL)
-const adminRow = table.getRow({ 
+const adminRow = table.getRow({
   Role: 'Admin',
   Status: 'Active'
 });
 
 // ✅ Regex matching
-const gmailRow = table.getRow({ 
-  Email: /@gmail\.com$/ 
+const gmailRow = table.getRow({
+  Email: /@gmail\.com$/
 });
 ```
 
@@ -182,6 +182,12 @@ const exactRow = await table.findRow(
 );
 ```
 
+### Interactive trace
+
+Step through how `findRow` scans pages, highlights matches, and surfaces the `maxPages` exhausted error — without running a real browser.
+
+<LabGetRowTrace />
+
 [Back to Top](#table-methods)
 
 ---
@@ -235,6 +241,12 @@ const exactRows = await table.findRows(
   { exact: true }
 );
 ```
+
+### See it in action
+
+Walk through a full `findRow` flow end-to-end: table init, header mapping, multi-page scan, match highlight, and the final `getCell` + checkbox interaction — all animated step by step.
+
+<LabFindRowPaginationDebug />
 
 [Back to Top](#table-methods)
 


### PR DESCRIPTION
## Summary

- Adds `<LabGetRowTrace />` as an **Interactive trace** subsection directly under the `findRow()` API entry — readers can step through page scanning, match highlighting, and the `maxPages` exhausted state without leaving the reference page.
- Adds `<LabFindRowPaginationDebug />` as a **See it in action** subsection under `findRows()` — walks through the full flow from `useTable` init → header mapping → multi-page scan → match → `getCell` + checkbox interaction.
- Both components are globally registered; no imports needed in the markdown.

## Test plan

- [ ] Run `npm run docs:dev` and navigate to `/api/table-methods`
- [ ] Verify `LabGetRowTrace` renders under `findRow()` with scenario toggle and step-through controls
- [ ] Verify `LabFindRowPaginationDebug` renders under `findRows()` with the debugger widget
- [ ] Confirm no layout regressions on the surrounding API entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced API documentation for table methods with newly added interactive walkthroughs for `findRow` and `findRows` operations
* Introduced embedded "lab" components enabling hands-on exploration of common table query patterns, advanced filtering techniques, and pagination debugging scenarios
* Reformatted filter examples throughout documentation with improved clarity and consistent styling for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->