### PR TITLE
docs: embed LabInitGetRowDebug in Getting Started — visualize init→getRow flow

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -28,9 +28,21 @@ test('find and verify employee', async ({ page }) => {
 
 ## Why This Works
 
-`useTable()` reads the table headers and remembers which column index belongs to each name. `getRow()` finds a row by cell text, and `getCell()` returns a normal Playwright `Locator`, so Playwright assertions and actions still work.
+Those three lines hide a small but important pipeline. Press **Play** to step through it and see what happens internally each time a line runs.
 
-That means your test can say “the row where `Name` is `Airi Satou`, then the `Office` cell” instead of relying on `nth()` indexes.
+<LabInitGetRowDebug />
+
+Here is what you just saw:
+
+1. **`init()` builds the header map.** Smart Table reads the `<th>` elements once and records which column index belongs to each name — for example `Name → 1`, `Office → 4`. This map is frozen for the lifetime of the table object, so every subsequent lookup is O(1).
+
+2. **`getRow()` translates your filter into a Playwright locator.** It looks up each key in the header map and builds a `.filter()` chain — one filter per column. No DOM access happens yet; you get back a locator that is ready to evaluate.
+
+3. **`getCell()` returns a plain Playwright `Locator`.** You can pass it straight to `expect()`, `click()`, `fill()`, or any other Playwright API.
+
+4. **Typos are caught at the filter stage.** If a key does not match any header, Smart Table throws immediately with a list of close matches — no cryptic “element not found” error deep in a test run.
+
+That is why your test can say “the row where `Name` is `Airi Satou`, then the `Office` cell” instead of relying on `nth()` indexes that break the moment a column is reordered.
 
 ## Which Method Should I Use?
 


### PR DESCRIPTION
## Summary

- Reworks the **Why This Works** section of `docs/guide/getting-started.md` from pure prose into a guided, interactive walkthrough
- Embeds `<LabInitGetRowDebug />` (globally registered, no import needed) so readers can step through the `init()` → `getRow()` pipeline in the browser
- Follows the widget with a numbered explanation that maps each debugger step to a concrete concept: header map construction, locator translation, `getCell` passthrough, and typo detection

## What the widget shows

The `LabInitGetRowDebug` component wraps `LabDebuggerWidget` and exposes four executable steps:

| Step | Code line | Variable revealed |
|---|---|---|
| 0 | `await table.init()` | `headerMap` — frozen column→index mapping |
| 1 | `table.getRow({ Name: 'Airi Satou' })` | Generated Playwright locator (`.filter()` chain) |
| 2 | `expect(row.getCell('Office')).toHaveText('Tokyo')` | `// True` — assertion result |
| 3 | `table.getRow({ Naem: 'Airi Satou' })` | Guided error with fuzzy suggestions |

## Test plan

- [ ] Run `npm run docs:dev` and navigate to `/guide/getting-started`
- [ ] Confirm the **Why This Works** section renders the debugger widget
- [ ] Step through all four lines with the Play button — each reveals the correct variable pane
- [ ] Confirm the typo step (line 4) shows the red error pane with fuzzy suggestions
- [ ] Check narrow viewport (≤ 980 px) — widget falls back to inline popover correctly
- [ ] Confirm surrounding prose is beginner-friendly and flows naturally before and after the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced getting-started guide with detailed step-by-step explanations
  * Added interactive debugging component for hands-on learning
  * Improved clarity on function behavior and error detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->