### PR TITLE
docs: add concurrency section with LabConcurrencyAnimator to Strategies page

### DIFF
--- a/docs/concepts/strategies.md
+++ b/docs/concepts/strategies.md
@@ -99,3 +99,72 @@ const myLoadingStrategy = {
     }
 };
 ```
+
+## Concurrency Strategy
+
+Strategies govern *how* the library performs individual operations. Concurrency governs *when* row callbacks run relative to each other during multi-row iteration (`forEach`, `map`, `filter`).
+
+Think of it as another axis of the strategy pattern: rather than swapping out the mechanism for pagination or sorting, you are swapping out the scheduler that decides whether rows are visited one at a time, all at once, or in coordinated batches.
+
+### The three modes
+
+**`sequential`** — one row at a time. The callback for row N finishes completely before the library touches row N+1. This is the safest default for callbacks that open tooltips, fill inputs, or mutate shared UI state.
+
+**`parallel`** — all rows on the current page start simultaneously. Pages are still processed in order, but within a page every row callback is launched without waiting for its neighbours. This is the fastest mode for pure data reads — no UI interaction, no shared state.
+
+**`synchronized`** — rows on a page start simultaneously like `parallel`, but the engine inserts a barrier at any point where all workers must agree on a shared position (for example, when scrolling a virtualized column into view). This prevents workers from racing each other to the same scroll target. Use it when your table virtualizes columns but you still want per-page concurrency.
+
+### Choosing the right mode
+
+| Table type | Recommended mode |
+| :--- | :--- |
+| All cells in the DOM, no UI interaction needed | `parallel` |
+| All cells in the DOM, callback opens a popover / tooltip | `sequential` |
+| Virtualized columns (horizontal scroll per row) | `synchronized` |
+| Any callback that mutates shared state | `sequential` |
+
+### Interactive demo
+
+The animation below runs the same 3-page `forEach` across all three modes simultaneously. Use the scenario tabs to load different table shapes and watch which modes break — and why.
+
+<LabConcurrencyAnimator />
+
+### Configuring concurrency
+
+Set a default at the table level (applies to every `forEach`, `map`, and `filter` call):
+
+```typescript
+const table = useTable(locator, {
+    concurrency: 'parallel'   // or 'sequential' | 'synchronized'
+});
+```
+
+Override per call when a single operation has different requirements:
+
+```typescript
+// Fast read — parallel is fine
+const statuses = await table.map(({ row }) =>
+    row.getCell('Status').innerText()
+);
+
+// Opens a tooltip — must be sequential
+const names = await table.map(async ({ row }) => {
+    await row.getCell('User').locator('.avatar').click();
+    const name = await page.locator('.tooltip .full-name').innerText();
+    await page.keyboard.press('Escape');
+    return name;
+}, { concurrency: 'sequential' });
+
+// Virtualized columns — synchronized keeps the scroll in sync
+await table.forEach(async ({ row }) => {
+    const dept = await row.getCell('Department').innerText();
+    // ...
+}, { concurrency: 'synchronized' });
+```
+
+### What to notice
+
+- **Sequential** always finishes last on multi-page tables: it waits for each row before moving to the next, so total time scales linearly with row count.
+- **Parallel** is fastest when callbacks are independent reads. It breaks when multiple callbacks compete for the same UI widget (tooltips, dropdowns) because only one element can be active at a time.
+- **Synchronized** matches `parallel` in speed for simple DOM tables — the barrier never fires because no column scrolling is needed. Prefer `parallel` in those cases.
+- The elapsed time badges in the demo reflect relative cost. At realistic speed the gap between sequential and parallel can be a 3× to 5× difference on a 9-row, 3-page table.


### PR DESCRIPTION
## Summary

- Adds a **## Concurrency Strategy** section to `docs/concepts/strategies.md`, extending the existing strategy pattern page with the concurrency scheduling axis
- Explains all three modes (`sequential`, `parallel`, `synchronized`) in the same conversational tone as the existing pagination/sorting/loading examples
- Embeds `<LabConcurrencyAnimator />` inline with a brief intro directing readers to use the scenario tabs
- Provides a decision table for choosing the right mode, TypeScript config snippets for both table-level defaults and per-call overrides, and a "What to notice" observation list tied to what the animation reveals

## Rationale

Rather than a standalone page, this treatment frames concurrency as another axis of the strategy pattern — the scheduler that decides *when* callbacks run, alongside strategies that decide *how* individual operations execute. This makes the mental model cohesive and keeps discoverable content in one place.

## Test plan

- [ ] `docs:dev` preview: navigate to Concepts → Understanding Strategies, confirm the new section renders, the animator loads, scenario tabs work, and code blocks are readable
- [ ] Verify `<LabConcurrencyAnimator />` responds to Run / scenario / speed controls
- [ ] Check mobile layout (single-column grid) via DevTools responsive mode
- [ ] Confirm no broken links or missing imports (component is globally registered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on concurrency strategies, explaining how concurrency controls row callbacks during multi-row operations.
  * Describes three concurrency modes—sequential, parallel, and synchronized—with guidance on when to use each.
  * Includes TypeScript examples, performance characteristics, and details on configuring defaults and per-call overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->