### PR TITLE
fix(ci): fix compare scroll sync — absolute pixels, reliable debounce

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -137,7 +137,10 @@ jobs:
 
               const fC = document.getElementById('f-canonical');
               const fP = document.getElementById('f-preview');
-              let syncing = false;
+              // Track which frame is the sync target to break the feedback loop.
+              // A timeout is more reliable than rAF because scrollTo() can fire
+              // the target's scroll event asynchronously.
+              let syncTarget = null;
 
               function navigate(page) {
                 fC.src = CANONICAL + (page || '');
@@ -148,16 +151,15 @@ jobs:
               }
 
               function syncScroll(src, tgt) {
-                if (syncing) return;
-                syncing = true;
+                if (syncTarget === src) return; // src is reacting to our own scrollTo — ignore
+                syncTarget = tgt;
                 try {
-                  const sw = src.contentWindow, tw = tgt.contentWindow;
-                  const ratio = sw.scrollY /
-                    Math.max(1, sw.document.body.scrollHeight - sw.innerHeight);
-                  tw.scrollTo(0,
-                    ratio * Math.max(0, tw.document.body.scrollHeight - tw.innerHeight));
+                  // Absolute pixel sync: same offset on both sides so you read
+                  // the same section. Ratio-based sync feels wrong when pages
+                  // have different heights (preview always has more content).
+                  tgt.contentWindow.scrollTo(0, src.contentWindow.scrollY);
                 } catch (_) {}
-                requestAnimationFrame(() => { syncing = false; });
+                setTimeout(() => { if (syncTarget === tgt) syncTarget = null; }, 50);
               }
 
               function attach(frame, other) {


### PR DESCRIPTION
## Problem
Two issues with the compare page scroll sync:

1. **Preview always scrolled further than canonical** — ratio-based sync maps 50% down canonical to 50% down preview. But when preview has more content (it does — it includes the new docs additions), the same ratio points to a different section. You want to read the same part of the page, not the proportionally equivalent position.

2. **Only the actively scrolled pane scrolled smoothly** — the `rAF`-based `syncing` flag reset could complete before the target frame's scroll event fired, causing the feedback loop to stutter rather than sync cleanly.

## Fix
- **Absolute pixel sync**: `tgt.scrollTo(0, src.scrollY)` — both panes show the same pixel offset so you're always reading the same section
- **Reliable debounce**: track which frame is the current sync *target* (not just a boolean), ignore scroll events from it for 50ms after `scrollTo()` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll synchronization between canonical and preview documentation versions for smoother side-by-side comparison navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->