### PR TITLE
fix(bot): CR rate-limit delay anchor + duplicate trigger guard + waiting→complete transition

### DIFF
--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -99,6 +99,12 @@ jobs:
 
             // On review events, re-evaluate thread state and auto-transition label
             if (context.eventName === 'pull_request_review') {
+              // Ignore skip/rate-limit notices — they fire pull_request_review events
+              // but are not real reviews, so 0 unresolved threads is meaningless.
+              const reviewBody = context.payload.review?.body || '';
+              const isSkipOrRateLimit = /skip review|rate.?limit/i.test(reviewBody);
+              if (isSkipOrRateLimit) return;
+
               const unresolved = await unresolvedCRThreadCount();
               const hasCRLabel = labelNames.some(n => n.startsWith('coderabbit:'));
               const isActive = hasCRLabel &&

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -101,16 +101,16 @@ jobs:
             if (context.eventName === 'pull_request_review') {
               const unresolved = await unresolvedCRThreadCount();
               const hasCRLabel = labelNames.some(n => n.startsWith('coderabbit:'));
-              // Only transition if we're already in an active CR state
-              if (hasCRLabel && !labelNames.includes('coderabbit: waiting') &&
+              const isActive = hasCRLabel &&
                   !labelNames.includes('coderabbit: rate-limited') &&
-                  !labelNames.includes('coderabbit: not started')) {
-                if (unresolved === 0 && labelNames.includes('coderabbit: unresolved')) {
+                  !labelNames.includes('coderabbit: not started');
+              if (isActive) {
+                if (unresolved === 0 && !labelNames.includes('coderabbit: complete')) {
                   await swapLabel('coderabbit: complete');
                   await postStatus('success', 'CodeRabbit review complete');
                   return;
                 }
-                if (unresolved > 0 && labelNames.includes('coderabbit: complete')) {
+                if (unresolved > 0 && !labelNames.includes('coderabbit: unresolved')) {
                   await swapLabel('coderabbit: unresolved');
                   await postStatus('failure', 'CodeRabbit has unresolved comments');
                   return;

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -498,6 +498,8 @@ jobs:
 
               const pr = gqlResult.repository.pullRequest;
 
+              const triggerDate = new Date(trigger_time);
+
               // Gate: CR updates its walkthrough issue comment first, then submits
               // the formal PR review (with inline threads) ~30s later. If no formal
               // review has landed yet, wait one more 60s cycle to avoid racing past
@@ -519,7 +521,6 @@ jobs:
                 t => !t.isResolved && isCR(t.comments.nodes[0]?.author?.login)
               );
 
-              const triggerDate = new Date(trigger_time);
               const crNitpickReviews = pr.reviews.nodes.filter(
                 r => isCR(r.author?.login) &&
                      r.state === 'COMMENTED' &&

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -28,6 +28,27 @@ jobs:
           script: |
             const { pr_number, repo } = context.payload.client_payload;
             const [owner, repoName] = repo.split('/');
+
+            // Guard: only fire if still rate-limited (duplicate QStash messages skip)
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner, repo: repoName, issue_number: pr_number
+            });
+            const labelNames = labels.map(l => l.name);
+            if (!labelNames.includes('coderabbit: rate-limited')) {
+              core.info(`PR #${pr_number} is no longer rate-limited (label: ${labelNames.join(', ')}), skipping retry`);
+              return;
+            }
+
+            // Swap label first so any subsequent duplicate messages skip
+            try {
+              await github.rest.issues.removeLabel({
+                owner, repo: repoName, issue_number: pr_number, name: 'coderabbit: rate-limited'
+              });
+            } catch {}
+            await github.rest.issues.addLabels({
+              owner, repo: repoName, issue_number: pr_number, labels: ['coderabbit: waiting']
+            });
+
             await github.rest.issues.createComment({
               owner,
               repo: repoName,

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -416,16 +416,24 @@ jobs:
               await swapLabel('coderabbit: rate-limited');
               await postStatus('pending', 'CodeRabbit rate-limited — retry queued');
 
-              // Parse duration from message
-              const durationMatch = rateLimitComment.body.match(/(\d+)\s*(minute|min|hour)/i);
-              let delaySecs = 30 * 60; // default 30 minutes
-              if (durationMatch) {
-                const val = parseInt(durationMatch[1]);
-                const unit = durationMatch[2].toLowerCase();
-                delaySecs = unit.startsWith('hour') ? val * 3600 : val * 60;
-              }
-              // Add 1 minute buffer
-              delaySecs += 60;
+              // Parse hours/minutes/seconds from the rate-limit comment body,
+              // then anchor to when CR *posted* the comment so elapsed processing
+              // time doesn't inflate the delay.
+              const body = rateLimitComment.body;
+              const hMatch = body.match(/(\d+)\s*hour/i);
+              const mMatch = body.match(/(\d+)\s*min/i);
+              const sMatch = body.match(/(\d+)\s*sec/i);
+              let durationMs =
+                (hMatch ? parseInt(hMatch[1]) * 3600000 : 0) +
+                (mMatch ? parseInt(mMatch[1]) * 60000   : 0) +
+                (sMatch ? parseInt(sMatch[1]) * 1000    : 0);
+              if (!durationMs) durationMs = 30 * 60 * 1000; // fallback 30 min
+
+              const commentedAt = new Date(rateLimitComment.created_at).getTime();
+              const availableAt = commentedAt + durationMs;
+              // 60s buffer after CR becomes available; floor at 30s in case we're
+              // already past the window when this handler runs.
+              const delaySecs = Math.max(30, Math.ceil((availableAt - Date.now()) / 1000)) + 60;
 
               await enqueue('bot-coderabbit-trigger', {
                 pr_number, repo, attempt: attempt + 1, hq_comment_id

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -451,7 +451,11 @@ jobs:
               if (!durationMs) durationMs = 30 * 60 * 1000; // fallback 30 min
 
               const commentedAt = new Date(rateLimitComment.created_at).getTime();
-              const availableAt = commentedAt + durationMs;
+              if (isNaN(commentedAt)) {
+                core.warning('Rate-limit comment missing valid created_at — falling back to 30 min from now');
+                durationMs = 30 * 60 * 1000;
+              }
+              const availableAt = (isNaN(commentedAt) ? Date.now() : commentedAt) + durationMs;
               // 60s buffer after CR becomes available; floor at 30s in case we're
               // already past the window when this handler runs.
               const delaySecs = Math.max(30, Math.ceil((availableAt - Date.now()) / 1000)) + 60;

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -109,6 +109,15 @@ jobs:
               return;
             }
 
+            // If a trigger is already in progress, don't stack another one.
+            // The in-flight bot-coderabbit-check will re-trigger if CR doesn't respond.
+            const isWaiting = labels.some(l => l.name === 'coderabbit: waiting');
+            if (isWaiting && attempt <= 1) {
+              core.info(`PR #${pr_number} already has a review in progress, skipping duplicate trigger`);
+              core.setOutput('stop', 'true');
+              return;
+            }
+
             if (attempt > 10) {
               await github.rest.issues.createComment({
                 owner, repo: repoName, issue_number: pr_number,


### PR DESCRIPTION
## Summary

- **Anchor rate-limit delay to comment creation time** — previously computed from "now" (processing time not subtracted), causing ~2.5 min overshoot
- **Parse hours/minutes/seconds** from rate-limit comment body (previously only hours+minutes)
- **Validate `created_at` before computing delay** — guard against NaN propagation if timestamp is missing/malformed
- **Guard `coderabbit-retry` against duplicate QStash messages** — checks label is still `rate-limited` before posting, swaps to `waiting` first so in-flight duplicates are no-ops
- **Guard `coderabbit-trigger` against duplicate triggers** — bail if label is already `waiting` and attempt ≤ 1, preventing parallel review loops from stacking
- **Fix `waiting` → `complete` transition in gate** — previously excluded `waiting` from the auto-transition block, so CR submitting a review while in waiting state never flipped the label
- **Fix TDZ crash** — `triggerDate` was declared after its first use, crashing the handler silently on every walkthrough comment

## Test plan
- [ ] Trigger a rate-limited PR — verify retry fires at the right time (not 2.5 min late)
- [ ] Verify duplicate QStash messages for the same PR don't each post `@coderabbitai full review`
- [ ] Verify a PR in `waiting` state transitions to `complete` when CR submits a no-findings review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized automated code review workflow to prevent duplicate reviews and improve status tracking.
  * Enhanced review thread detection to more accurately reflect review progress and completion states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->