### PR TITLE
test(bot): extract CR logic into testable module + 52 unit tests

### DIFF
--- a/.github/scripts/coderabbit-logic.mjs
+++ b/.github/scripts/coderabbit-logic.mjs
@@ -10,7 +10,7 @@
  * @param {string|null|undefined} body
  */
 export function isSkipOrRateLimitReview(body) {
-  return /skip review|rate.?limit/i.test(body ?? '');
+  return /auto-generated comment: (?:rate limited|skip review) by coderabbit\.ai/i.test(body ?? '');
 }
 
 /**

--- a/.github/scripts/coderabbit-logic.mjs
+++ b/.github/scripts/coderabbit-logic.mjs
@@ -1,0 +1,130 @@
+/**
+ * Pure functions for CodeRabbit bot logic.
+ * Imported by bot-coderabbit-gate.yml and bot-receiver.yml via dynamic import,
+ * and tested by tests/unit/bot/coderabbit-logic.test.ts.
+ */
+
+/**
+ * Returns true if a pull_request_review body is a skip or rate-limit notice —
+ * not a real substantive review. These events must not trigger label transitions.
+ * @param {string|null|undefined} body
+ */
+export function isSkipOrRateLimitReview(body) {
+  return /skip review|rate.?limit/i.test(body ?? '');
+}
+
+/**
+ * Given the current label names and the count of unresolved CR threads,
+ * decides what label transition the gate should perform.
+ *
+ * Returns { newLabel, state, description } or null if no transition is needed.
+ *
+ * @param {string[]} labelNames
+ * @param {number} unresolved
+ */
+export function computeGateTransition(labelNames, unresolved) {
+  const hasCRLabel = labelNames.some(n => n.startsWith('coderabbit:'));
+  const isActive = hasCRLabel
+    && !labelNames.includes('coderabbit: rate-limited')
+    && !labelNames.includes('coderabbit: not started');
+  if (!isActive) return null;
+
+  if (unresolved === 0 && !labelNames.includes('coderabbit: complete'))
+    return { newLabel: 'coderabbit: complete', state: 'success', description: 'CodeRabbit review complete' };
+
+  if (unresolved > 0 && !labelNames.includes('coderabbit: unresolved'))
+    return { newLabel: 'coderabbit: unresolved', state: 'failure', description: 'CodeRabbit has unresolved comments' };
+
+  return null;
+}
+
+/**
+ * Maps the current label set to a commit status to post.
+ * @param {string[]} labelNames
+ * @returns {{ state: string, description: string }}
+ */
+export function labelToStatus(labelNames) {
+  if (labelNames.includes('coderabbit: complete'))
+    return { state: 'success', description: 'CodeRabbit review complete' };
+  if (labelNames.includes('coderabbit: unresolved'))
+    return { state: 'failure', description: 'CodeRabbit has unresolved comments' };
+  if (labelNames.includes('coderabbit: rate-limited'))
+    return { state: 'pending', description: 'CodeRabbit rate-limited — retry queued' };
+  if (labelNames.includes('coderabbit: waiting'))
+    return { state: 'pending', description: 'CodeRabbit review in progress' };
+  return { state: 'pending', description: 'CodeRabbit review not started — comment @rickcedwhat-ai coderabbit review' };
+}
+
+/**
+ * Filters GraphQL reviewThreads nodes and returns the count of unresolved CR threads.
+ * @param {Array<{ isResolved: boolean, comments: { nodes: Array<{ author: { login: string }|null }> } }>} nodes
+ */
+export function countUnresolvedCRThreads(nodes) {
+  return nodes.filter(
+    t => !t.isResolved && t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
+  ).length;
+}
+
+/**
+ * Parses the wait duration from a CodeRabbit rate-limit comment body.
+ * Looks for hours, minutes, and seconds independently.
+ * Returns milliseconds; falls back to 30 minutes if nothing matches.
+ * @param {string} body
+ */
+export function parseRateLimitDuration(body) {
+  const hMatch = body.match(/(\d+)\s*hour/i);
+  const mMatch = body.match(/(\d+)\s*min/i);
+  const sMatch = body.match(/(\d+)\s*sec/i);
+  const ms = (hMatch ? parseInt(hMatch[1]) * 3_600_000 : 0)
+           + (mMatch ? parseInt(mMatch[1]) *    60_000 : 0)
+           + (sMatch ? parseInt(sMatch[1]) *     1_000 : 0);
+  return ms || 30 * 60_000;
+}
+
+/**
+ * Computes the QStash delay in seconds for a rate-limit retry.
+ *
+ * Anchors to when CR *posted* the rate-limit comment (createdAtIso) so elapsed
+ * processing time doesn't inflate the delay. Falls back to now if the timestamp
+ * is missing or malformed. Always adds a 60 s safety buffer.
+ *
+ * @param {string} body          - Rate-limit comment body text
+ * @param {string|null} createdAtIso - ISO timestamp of the rate-limit comment
+ * @param {number} nowMs         - Current time as Unix ms (Date.now())
+ * @returns {number} Delay in seconds (minimum 90)
+ */
+export function computeRateLimitDelay(body, createdAtIso, nowMs) {
+  const durationMs = parseRateLimitDuration(body);
+  const commentedAt = createdAtIso ? new Date(createdAtIso).getTime() : NaN;
+  const anchor = isNaN(commentedAt) ? nowMs : commentedAt;
+  const availableAt = anchor + durationMs;
+  return Math.max(30, Math.ceil((availableAt - nowMs) / 1_000)) + 60;
+}
+
+/**
+ * Returns true if the coderabbit-retry job should skip because the PR is
+ * no longer rate-limited (duplicate QStash messages in flight).
+ * @param {string[]} labelNames
+ */
+export function shouldSkipRetry(labelNames) {
+  return !labelNames.includes('coderabbit: rate-limited');
+}
+
+/**
+ * Returns true if the coderabbit-trigger job should skip.
+ *
+ * Skips when the PR is already in a terminal state (complete/unresolved),
+ * or when a review is already in-progress (waiting) and this is a first-attempt
+ * trigger — which means it's a duplicate. Retries from bot-coderabbit-check
+ * arrive with attempt > 1 and must proceed even when waiting.
+ *
+ * @param {string[]} labelNames
+ * @param {number} attempt - 1-based attempt number
+ */
+export function shouldSkipTrigger(labelNames, attempt) {
+  if (labelNames.includes('coderabbit: complete') || labelNames.includes('coderabbit: unresolved'))
+    return true;
+  if (labelNames.includes('coderabbit: waiting') && attempt <= 1)
+    return true;
+  return false;
+}

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -23,9 +23,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v4
 
       - name: Update commit status from label
         uses: actions/github-script@v9

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -22,11 +22,24 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Update commit status from label
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
+            const path = require('path');
+            const {
+              isSkipOrRateLimitReview,
+              computeGateTransition,
+              countUnresolvedCRThreads,
+              labelToStatus,
+            } = await import(
+              `file://${path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/coderabbit-logic.mjs')}`
+            );
+
             const { owner, repo } = context.repo;
 
             const pr_number = context.payload.pull_request
@@ -73,8 +86,13 @@ jobs:
               });
             }
 
-            // Helper: count unresolved CodeRabbit threads via GraphQL
-            async function unresolvedCRThreadCount() {
+            // On review events, re-evaluate thread state and auto-transition label
+            if (context.eventName === 'pull_request_review') {
+              // Ignore skip/rate-limit notices — they fire pull_request_review events
+              // but are not real reviews, so 0 unresolved threads is meaningless.
+              const reviewBody = context.payload.review?.body || '';
+              if (isSkipOrRateLimitReview(reviewBody)) return;
+
               const result = await github.graphql(`
                 query($owner: String!, $repo: String!, $number: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -91,43 +109,18 @@ jobs:
                   }
                 }
               `, { owner, repo, number: Number(pr_number) });
-              return result.repository.pullRequest.reviewThreads.nodes.filter(
-                t => !t.isResolved &&
-                     t.comments.nodes[0]?.author?.login === 'coderabbitai[bot]'
-              ).length;
-            }
 
-            // On review events, re-evaluate thread state and auto-transition label
-            if (context.eventName === 'pull_request_review') {
-              const unresolved = await unresolvedCRThreadCount();
-              const hasCRLabel = labelNames.some(n => n.startsWith('coderabbit:'));
-              // Only transition if we're already in an active CR state
-              if (hasCRLabel && !labelNames.includes('coderabbit: waiting') &&
-                  !labelNames.includes('coderabbit: rate-limited') &&
-                  !labelNames.includes('coderabbit: not started')) {
-                if (unresolved === 0 && labelNames.includes('coderabbit: unresolved')) {
-                  await swapLabel('coderabbit: complete');
-                  await postStatus('success', 'CodeRabbit review complete');
-                  return;
-                }
-                if (unresolved > 0 && labelNames.includes('coderabbit: complete')) {
-                  await swapLabel('coderabbit: unresolved');
-                  await postStatus('failure', 'CodeRabbit has unresolved comments');
-                  return;
-                }
+              const unresolved = countUnresolvedCRThreads(
+                result.repository.pullRequest.reviewThreads.nodes
+              );
+              const transition = computeGateTransition(labelNames, unresolved);
+              if (transition) {
+                await swapLabel(transition.newLabel);
+                await postStatus(transition.state, transition.description);
+                return;
               }
             }
 
             // Map label to commit status
-            if (labelNames.includes('coderabbit: complete')) {
-              await postStatus('success', 'CodeRabbit review complete');
-            } else if (labelNames.includes('coderabbit: unresolved')) {
-              await postStatus('failure', 'CodeRabbit has unresolved comments');
-            } else if (labelNames.includes('coderabbit: rate-limited')) {
-              await postStatus('pending', 'CodeRabbit rate-limited — retry queued');
-            } else if (labelNames.includes('coderabbit: waiting')) {
-              await postStatus('pending', 'CodeRabbit review in progress');
-            } else {
-              // not started or no coderabbit label
-              await postStatus('pending', 'CodeRabbit review not started — comment @rickcedwhat-ai coderabbit review');
-            }
+            const { state, description } = labelToStatus(labelNames);
+            await postStatus(state, description);

--- a/.github/workflows/bot-coderabbit-gate.yml
+++ b/.github/workflows/bot-coderabbit-gate.yml
@@ -23,7 +23,9 @@ jobs:
       statuses: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Update commit status from label
         uses: actions/github-script@v9

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -109,6 +109,15 @@ jobs:
               return;
             }
 
+            // If a trigger is already in progress, don't stack another one.
+            // The in-flight bot-coderabbit-check will re-trigger if CR doesn't respond.
+            const isWaiting = labels.some(l => l.name === 'coderabbit: waiting');
+            if (isWaiting && attempt <= 1) {
+              core.info(`PR #${pr_number} already has a review in progress, skipping duplicate trigger`);
+              core.setOutput('stop', 'true');
+              return;
+            }
+
             if (attempt > 10) {
               await github.rest.issues.createComment({
                 owner, repo: repoName, issue_number: pr_number,

--- a/tests/unit/bot/coderabbit-logic.test.ts
+++ b/tests/unit/bot/coderabbit-logic.test.ts
@@ -19,14 +19,16 @@ describe('isSkipOrRateLimitReview', () => {
     )).toBe(true);
   });
 
-  it('matches "rate limited" body', () => {
+  it('matches "rate limited" CR auto-generated comment', () => {
     expect(isSkipOrRateLimitReview(
-      '## Review limit reached\n`@rickcedwhat-ai`, we couldn\'t start this review because you\'ve reached your PR review rate limit.'
+      '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->'
     )).toBe(true);
   });
 
-  it('matches "rate-limited" (hyphenated)', () => {
-    expect(isSkipOrRateLimitReview('rate-limited by coderabbit')).toBe(true);
+  it('does not match a real review body with "rate limit" in prose', () => {
+    expect(isSkipOrRateLimitReview(
+      '**Actionable comments posted: 1**\n\nThis function has no rate limit handling.'
+    )).toBe(false);
   });
 
   it('does not match a real review body', () => {

--- a/tests/unit/bot/coderabbit-logic.test.ts
+++ b/tests/unit/bot/coderabbit-logic.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSkipOrRateLimitReview,
+  computeGateTransition,
+  labelToStatus,
+  countUnresolvedCRThreads,
+  parseRateLimitDuration,
+  computeRateLimitDelay,
+  shouldSkipRetry,
+  shouldSkipTrigger,
+} from '../../../.github/scripts/coderabbit-logic.mjs';
+
+// ─── isSkipOrRateLimitReview ─────────────────────────────────────────────────
+
+describe('isSkipOrRateLimitReview', () => {
+  it('matches "skip review" in CR auto-generated body', () => {
+    expect(isSkipOrRateLimitReview(
+      '<!-- auto-generated comment: skip review by coderabbit.ai -->'
+    )).toBe(true);
+  });
+
+  it('matches "rate limited" body', () => {
+    expect(isSkipOrRateLimitReview(
+      '## Review limit reached\n`@rickcedwhat-ai`, we couldn\'t start this review because you\'ve reached your PR review rate limit.'
+    )).toBe(true);
+  });
+
+  it('matches "rate-limited" (hyphenated)', () => {
+    expect(isSkipOrRateLimitReview('rate-limited by coderabbit')).toBe(true);
+  });
+
+  it('does not match a real review body', () => {
+    expect(isSkipOrRateLimitReview('**Actionable comments posted: 2**')).toBe(false);
+  });
+
+  it('does not match an empty body', () => {
+    expect(isSkipOrRateLimitReview('')).toBe(false);
+  });
+
+  it('handles null/undefined gracefully', () => {
+    expect(isSkipOrRateLimitReview(null)).toBe(false);
+    expect(isSkipOrRateLimitReview(undefined)).toBe(false);
+  });
+});
+
+// ─── computeGateTransition ───────────────────────────────────────────────────
+
+describe('computeGateTransition', () => {
+  // Bug regression: waiting → complete was broken (waiting was excluded from isActive)
+  it('transitions waiting → complete when unresolved=0', () => {
+    const result = computeGateTransition(['coderabbit: waiting'], 0);
+    expect(result).toEqual({
+      newLabel: 'coderabbit: complete',
+      state: 'success',
+      description: 'CodeRabbit review complete',
+    });
+  });
+
+  it('transitions waiting → unresolved when threads exist', () => {
+    const result = computeGateTransition(['coderabbit: waiting'], 3);
+    expect(result).toEqual({
+      newLabel: 'coderabbit: unresolved',
+      state: 'failure',
+      description: 'CodeRabbit has unresolved comments',
+    });
+  });
+
+  it('transitions unresolved → complete when all threads resolved', () => {
+    const result = computeGateTransition(['coderabbit: unresolved'], 0);
+    expect(result?.newLabel).toBe('coderabbit: complete');
+  });
+
+  it('transitions complete → unresolved when new threads appear', () => {
+    const result = computeGateTransition(['coderabbit: complete'], 1);
+    expect(result?.newLabel).toBe('coderabbit: unresolved');
+  });
+
+  it('returns null when already complete with 0 threads (no change needed)', () => {
+    expect(computeGateTransition(['coderabbit: complete'], 0)).toBeNull();
+  });
+
+  it('returns null when already unresolved with threads (no change needed)', () => {
+    expect(computeGateTransition(['coderabbit: unresolved'], 2)).toBeNull();
+  });
+
+  it('returns null for rate-limited (not active)', () => {
+    expect(computeGateTransition(['coderabbit: rate-limited'], 0)).toBeNull();
+  });
+
+  it('returns null for not-started (not active)', () => {
+    expect(computeGateTransition(['coderabbit: not started'], 0)).toBeNull();
+  });
+
+  it('returns null when no CR label at all', () => {
+    expect(computeGateTransition(['bug', 'enhancement'], 0)).toBeNull();
+  });
+
+  it('returns null for empty label list', () => {
+    expect(computeGateTransition([], 0)).toBeNull();
+  });
+});
+
+// ─── labelToStatus ───────────────────────────────────────────────────────────
+
+describe('labelToStatus', () => {
+  it('complete → success', () => {
+    expect(labelToStatus(['coderabbit: complete'])).toEqual({
+      state: 'success',
+      description: 'CodeRabbit review complete',
+    });
+  });
+
+  it('unresolved → failure', () => {
+    expect(labelToStatus(['coderabbit: unresolved'])).toEqual({
+      state: 'failure',
+      description: 'CodeRabbit has unresolved comments',
+    });
+  });
+
+  it('rate-limited → pending with retry message', () => {
+    const { state, description } = labelToStatus(['coderabbit: rate-limited']);
+    expect(state).toBe('pending');
+    expect(description).toMatch(/rate-limited/i);
+  });
+
+  it('waiting → pending with in-progress message', () => {
+    const { state, description } = labelToStatus(['coderabbit: waiting']);
+    expect(state).toBe('pending');
+    expect(description).toMatch(/in progress/i);
+  });
+
+  it('not started → pending with not-started message', () => {
+    const { state } = labelToStatus(['coderabbit: not started']);
+    expect(state).toBe('pending');
+  });
+
+  it('no label → pending', () => {
+    expect(labelToStatus([])).toMatchObject({ state: 'pending' });
+  });
+});
+
+// ─── countUnresolvedCRThreads ─────────────────────────────────────────────────
+
+describe('countUnresolvedCRThreads', () => {
+  const crThread = (isResolved: boolean) => ({
+    isResolved,
+    comments: { nodes: [{ author: { login: 'coderabbitai[bot]' } }] },
+  });
+  const userThread = (isResolved: boolean) => ({
+    isResolved,
+    comments: { nodes: [{ author: { login: 'some-user' } }] },
+  });
+  const emptyThread = () => ({
+    isResolved: false,
+    comments: { nodes: [] },
+  });
+
+  it('counts unresolved CR threads', () => {
+    expect(countUnresolvedCRThreads([crThread(false), crThread(false)])).toBe(2);
+  });
+
+  it('ignores resolved CR threads', () => {
+    expect(countUnresolvedCRThreads([crThread(true), crThread(false)])).toBe(1);
+  });
+
+  it('ignores non-CR threads', () => {
+    expect(countUnresolvedCRThreads([userThread(false), crThread(false)])).toBe(1);
+  });
+
+  it('ignores threads with no author', () => {
+    expect(countUnresolvedCRThreads([emptyThread(), crThread(false)])).toBe(1);
+  });
+
+  it('returns 0 for empty list', () => {
+    expect(countUnresolvedCRThreads([])).toBe(0);
+  });
+
+  it('returns 0 when all threads resolved', () => {
+    expect(countUnresolvedCRThreads([crThread(true), crThread(true)])).toBe(0);
+  });
+});
+
+// ─── parseRateLimitDuration ──────────────────────────────────────────────────
+
+describe('parseRateLimitDuration', () => {
+  it('parses hours', () => {
+    expect(parseRateLimitDuration('available in 1 hour')).toBe(3_600_000);
+  });
+
+  it('parses minutes', () => {
+    expect(parseRateLimitDuration('available in 30 minutes')).toBe(1_800_000);
+  });
+
+  it('parses seconds', () => {
+    expect(parseRateLimitDuration('available in 45 seconds')).toBe(45_000);
+  });
+
+  // Regression: old code only parsed hours+minutes, dropped seconds
+  it('parses combined hours, minutes, and seconds', () => {
+    expect(parseRateLimitDuration('available in 1 hour 30 minutes and 15 seconds'))
+      .toBe(3_600_000 + 1_800_000 + 15_000);
+  });
+
+  it('parses the real CR format "41 minutes and 59 seconds"', () => {
+    expect(parseRateLimitDuration(
+      'More reviews will be available in 41 minutes and 59 seconds.'
+    )).toBe(41 * 60_000 + 59 * 1_000);
+  });
+
+  it('falls back to 30 minutes when no time found', () => {
+    expect(parseRateLimitDuration('rate limit reached, try again later')).toBe(30 * 60_000);
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseRateLimitDuration('Available in 2 Hours')).toBe(7_200_000);
+  });
+});
+
+// ─── computeRateLimitDelay ───────────────────────────────────────────────────
+
+describe('computeRateLimitDelay', () => {
+  const commentBody = 'available in 30 minutes';
+
+  // Regression: old code used Date.now() as anchor, inflating delay by processing time
+  it('anchors to comment creation time, not now', () => {
+    const commentedAt = new Date('2026-05-30T10:00:00Z').getTime();
+    const now = commentedAt + 5 * 60_000; // 5 minutes have elapsed since comment
+    const delay = computeRateLimitDelay(commentBody, '2026-05-30T10:00:00Z', now);
+    // 30 min window - 5 min elapsed = 25 min remaining + 60s buffer
+    expect(delay).toBe(25 * 60 + 60);
+  });
+
+  it('returns minimum 90 seconds even if window has passed', () => {
+    const commentedAt = new Date('2026-05-30T10:00:00Z').getTime();
+    const now = commentedAt + 60 * 60_000; // 60 minutes elapsed, well past 30min window
+    const delay = computeRateLimitDelay(commentBody, '2026-05-30T10:00:00Z', now);
+    expect(delay).toBe(90); // max(30, negative→0 rounded up to 30) + 60 = 90
+  });
+
+  // Regression: old code passed NaN to QStash when created_at missing
+  it('falls back to now-anchored delay when created_at is null', () => {
+    const now = Date.now();
+    const delay = computeRateLimitDelay(commentBody, null, now);
+    // 30 min from now + 60s buffer (no time elapsed from anchor=now)
+    expect(delay).toBe(30 * 60 + 60);
+  });
+
+  it('falls back to now-anchored delay when created_at is malformed', () => {
+    const now = Date.now();
+    const delay = computeRateLimitDelay(commentBody, 'not-a-date', now);
+    expect(delay).toBe(30 * 60 + 60);
+  });
+
+  it('result is always a finite positive number', () => {
+    const delay = computeRateLimitDelay('', null, Date.now());
+    expect(Number.isFinite(delay)).toBe(true);
+    expect(delay).toBeGreaterThan(0);
+  });
+});
+
+// ─── shouldSkipRetry ─────────────────────────────────────────────────────────
+
+describe('shouldSkipRetry', () => {
+  // Regression: bot was posting @coderabbitai full review on every duplicate QStash message
+  it('does NOT skip when label is rate-limited', () => {
+    expect(shouldSkipRetry(['coderabbit: rate-limited'])).toBe(false);
+  });
+
+  it('skips when label is waiting (already triggered)', () => {
+    expect(shouldSkipRetry(['coderabbit: waiting'])).toBe(true);
+  });
+
+  it('skips when label is complete', () => {
+    expect(shouldSkipRetry(['coderabbit: complete'])).toBe(true);
+  });
+
+  it('skips when no CR label', () => {
+    expect(shouldSkipRetry([])).toBe(true);
+  });
+});
+
+// ─── shouldSkipTrigger ───────────────────────────────────────────────────────
+
+describe('shouldSkipTrigger', () => {
+  // Regression: duplicate bot-coderabbit-trigger messages stacked parallel review loops
+  it('skips when complete regardless of attempt', () => {
+    expect(shouldSkipTrigger(['coderabbit: complete'], 1)).toBe(true);
+    expect(shouldSkipTrigger(['coderabbit: complete'], 5)).toBe(true);
+  });
+
+  it('skips when unresolved regardless of attempt', () => {
+    expect(shouldSkipTrigger(['coderabbit: unresolved'], 1)).toBe(true);
+    expect(shouldSkipTrigger(['coderabbit: unresolved'], 3)).toBe(true);
+  });
+
+  it('skips when waiting + attempt 1 (duplicate trigger)', () => {
+    expect(shouldSkipTrigger(['coderabbit: waiting'], 1)).toBe(true);
+  });
+
+  it('does NOT skip when waiting + attempt 2 (retry from check loop)', () => {
+    expect(shouldSkipTrigger(['coderabbit: waiting'], 2)).toBe(false);
+  });
+
+  it('does NOT skip when waiting + attempt 5', () => {
+    expect(shouldSkipTrigger(['coderabbit: waiting'], 5)).toBe(false);
+  });
+
+  it('does NOT skip when not-started + attempt 1 (fresh trigger)', () => {
+    expect(shouldSkipTrigger(['coderabbit: not started'], 1)).toBe(false);
+  });
+
+  it('does NOT skip when rate-limited + attempt 1 (post-rate-limit retry)', () => {
+    expect(shouldSkipTrigger(['coderabbit: rate-limited'], 1)).toBe(false);
+  });
+
+  it('does NOT skip when no label', () => {
+    expect(shouldSkipTrigger([], 1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the pure decision logic from `bot-coderabbit-gate.yml` and `bot-receiver.yml` into `.github/scripts/coderabbit-logic.mjs`
- Refactors `bot-coderabbit-gate.yml` to import from that module (cleaner, shorter script block)
- Adds 52 unit tests in `tests/unit/bot/coderabbit-logic.test.ts` covering all 8 functions
- Includes all fixes from #199 (`fix/cr-ratelimit-delay`) — this PR supersedes it

## Functions extracted

| Function | Protects against |
|---|---|
| `isSkipOrRateLimitReview` | Skip/rate-limit notices falsely completing a PR |
| `computeGateTransition` | `waiting→complete` never firing; `complete↔unresolved` not flipping |
| `labelToStatus` | Wrong commit status for any label state |
| `countUnresolvedCRThreads` | Non-CR or resolved threads being counted |
| `parseRateLimitDuration` | Seconds dropped; no-match returning 0 instead of 30min |
| `computeRateLimitDelay` | Anchoring to "now" instead of comment time; NaN from null `created_at` |
| `shouldSkipRetry` | Duplicate QStash `bot-coderabbit-retry` messages each posting a review |
| `shouldSkipTrigger` | Parallel trigger loops stacking when already waiting |

## Test plan
- [ ] `pnpm run test:unit` passes (52/52)
- [ ] Queue a CR review on a docs PR and verify `waiting→complete` transition fires correctly after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CodeRabbit bot automation with improved rate-limit handling and duplicate trigger prevention.
  * Added comprehensive test coverage for bot automation helper functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rickcedwhat/playwright-smart-table/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->