### PR TITLE
fix(bot): anchor rate-limit delay to updated_at, not created_at

### DIFF
--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -459,9 +459,13 @@ jobs:
                 (sMatch ? parseInt(sMatch[1]) * 1000    : 0);
               if (!durationMs) durationMs = 30 * 60 * 1000; // fallback 30 min
 
-              const commentedAt = new Date(rateLimitComment.created_at).getTime();
+              // CR updates the same comment in-place on re-triggers rather than
+              // posting a new one, so created_at can be hours stale. Use updated_at
+              // when available — it reflects when CR wrote the current timing text.
+              const anchorIso = rateLimitComment.updated_at ?? rateLimitComment.created_at;
+              const commentedAt = new Date(anchorIso).getTime();
               if (isNaN(commentedAt)) {
-                core.warning('Rate-limit comment missing valid created_at — falling back to 30 min from now');
+                core.warning('Rate-limit comment missing valid timestamp — falling back to 30 min from now');
                 durationMs = 30 * 60 * 1000;
               }
               const availableAt = (isNaN(commentedAt) ? Date.now() : commentedAt) + durationMs;


### PR DESCRIPTION
## Summary

- CR updates its rate-limit comment **in-place** on every re-trigger rather than posting a new one — so `created_at` is frozen at the original post time (potentially hours/days ago) while the body contains fresh timing
- Anchoring to `created_at` made `availableAt` land in the past, collapsing the QStash delay to `max(30,…)+60 = 90s` and showing **"⚠️ Rate limited — retrying in ~2m"** regardless of the actual wait (e.g. 56 minutes)
- Fix: use `updated_at ?? created_at` as the anchor — `updated_at` reflects when CR last wrote the current timing text

## Test plan

- [ ] Trigger a review on a rate-limited PR and confirm the HQ comment shows the correct wait time (~56m, not ~2m)
- [ ] Confirm QStash delay matches the displayed time

🤖 Generated with [Claude Code](https://claude.ai/claude-code)