### PR TITLE
fix(bot): clear existing CR labels before setting coderabbit:queued

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -63,7 +63,10 @@ jobs:
               rateLimitedIssues.some(i => i.pull_request && i.number !== prNumber);
 
             if (isBlocked) {
-              // Queue this PR — another review is already running
+              // Clear existing CR labels before setting queued (prevents duplicate labels)
+              for (const l of currentLabels.filter(l => l.name.startsWith('coderabbit:'))) {
+                try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: l.name }); } catch {}
+              }
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['coderabbit: queued'] });
               const queuedContent = [
                 '### 🔍 CodeRabbit Review',

--- a/.github/workflows/bot-receiver.yml
+++ b/.github/workflows/bot-receiver.yml
@@ -353,15 +353,12 @@ jobs:
 
                 const nextNum = nextPR.number;
 
-                // Swap queued → waiting
+                // Clear queued label — trigger job owns the queued→waiting transition
                 try {
                   await github.rest.issues.removeLabel({
                     owner, repo: repoName, issue_number: nextNum, name: 'coderabbit: queued'
                   });
                 } catch {}
-                await github.rest.issues.addLabels({
-                  owner, repo: repoName, issue_number: nextNum, labels: ['coderabbit: waiting']
-                });
 
                 // Find HQ comment
                 const nextComments = await github.paginate(github.rest.issues.listComments, {


### PR DESCRIPTION
## Summary

- The `isBlocked` path in the HQ checkbox handler added `coderabbit: queued` without first removing the existing CR label (e.g. `coderabbit: not started`), leaving PRs with two conflicting CR labels simultaneously
- PRs 191 and 192 were affected — labels manually corrected

## Test plan

- [ ] Trigger the checkbox on a PR while another review is in progress — confirm only `coderabbit: queued` appears, not `queued` + `not started`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)