### PR TITLE
debug(bot): trigger logging + gate workflow_dispatch

### DIFF
--- a/.github/workflows/bot-cr-gate.yml
+++ b/.github/workflows/bot-cr-gate.yml
@@ -11,6 +11,12 @@ name: Bot — CR Gate
 on:
   pull_request_review_thread:
     types: [resolved, unresolved]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to run gate check on'
+        required: true
+        type: string
 
 jobs:
   gate:
@@ -34,13 +40,31 @@ jobs:
             );
 
             const { owner, repo } = context.repo;
-            const pr_number = context.payload.pull_request.number;
-            const sha = context.payload.pull_request.head.sha;
-            const threadAction = context.payload.action; // 'resolved' | 'unresolved'
+
+            // Support manual workflow_dispatch for testing gate logic
+            const isManualDispatch = context.eventName === 'workflow_dispatch';
+            core.info(`[debug] eventName=${context.eventName}, isManualDispatch=${isManualDispatch}`);
+            core.info(`[debug] payload keys: ${Object.keys(context.payload).join(', ')}`);
+
+            let pr_number, sha, threadAction, baseBranch;
+
+            if (isManualDispatch) {
+              pr_number = parseInt(context.payload.inputs.pr_number);
+              threadAction = 'resolved'; // assume resolved when manually dispatched
+              const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: pr_number });
+              sha = pr.head.sha;
+              baseBranch = pr.base.ref;
+              core.info(`[debug] Manual dispatch for PR #${pr_number}, base=${baseBranch}`);
+            } else {
+              pr_number = context.payload.pull_request.number;
+              sha = context.payload.pull_request.head.sha;
+              threadAction = context.payload.action; // 'resolved' | 'unresolved'
+              baseBranch = context.payload.pull_request.base.ref;
+              core.info(`[debug] pull_request_review_thread event fired! action=${threadAction}, PR #${pr_number}`);
+            }
 
             // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
             // Remove this block when promoting to main.
-            const baseBranch = context.payload.pull_request.base.ref;
             if (baseBranch !== 'coderabbit') {
               core.info(`PR #${pr_number} targets "${baseBranch}", not "coderabbit" — skipping (test guard).`);
               return;

--- a/.github/workflows/bot-cr-trigger.yml
+++ b/.github/workflows/bot-cr-trigger.yml
@@ -134,15 +134,27 @@ jobs:
             // straight to rate-limited + QStash. If the window has already passed,
             // proceed normally — the quota should have refreshed.
 
+            // DEBUG: log all CR comments found and rate-limit detection results
+            const crComments = allComments.filter(c => c.user.login === 'coderabbitai[bot]');
+            core.info(`[debug] Total comments: ${allComments.length}, CR comments: ${crComments.length}`);
+            for (const c of crComments) {
+              const matches = isRateLimitComment(c.body);
+              core.info(`[debug] CR comment at ${c.created_at}: isRateLimitComment=${matches}, body[:120]="${c.body.slice(0, 120).replace(/\n/g, '\\n')}"`);
+            }
+
             const crRateLimitComment = allComments.find(
               c => c.user.login === 'coderabbitai[bot]' && isRateLimitComment(c.body)
             );
+
+            core.info(`[debug] crRateLimitComment found: ${!!crRateLimitComment}`);
 
             if (crRateLimitComment) {
               const durationMs = parseRateLimitDuration(crRateLimitComment.body);
               const commentedAt = new Date(crRateLimitComment.created_at).getTime();
               const availableAt = commentedAt + durationMs;
               const remainingSecs = Math.ceil((availableAt - Date.now()) / 1000);
+
+              core.info(`[debug] durationMs=${durationMs}, commentedAt=${crRateLimitComment.created_at}, remainingSecs=${remainingSecs}`);
 
               if (remainingSecs > 60) {
                 // Still rate-limited — go straight to rate-limited + QStash


### PR DESCRIPTION
Diagnostic additions to understand two unsolved bugs.

**`bot-cr-trigger` logging** — on every trigger, logs:
- All CR comments on the PR at trigger time and their timestamps
- Whether each matched `isRateLimitComment()`
- Whether `crRateLimitComment` was found
- The computed `durationMs`, `remainingSecs`

This will tell us definitively: was the rate-limit comment there? Did the pattern match? Was the window still open?

**`bot-cr-gate` workflow_dispatch** — gate can now be invoked manually via Actions UI with a `pr_number` input. Also logs `eventName` and payload keys on every run so we can confirm whether `pull_request_review_thread` ever fires in practice.

Not intended to merge long-term — remove logging before promoting to main.