### PR TITLE
fix(bot): detect rate-limit when CR edits its summary comment

### DIFF
--- a/.github/workflows/bot-cr-watch.yml
+++ b/.github/workflows/bot-cr-watch.yml
@@ -1,9 +1,13 @@
 name: Bot — CR Watch
 
-# Fires on every issue_comment from coderabbitai[bot].
-# Guards: PR must have "coderabbit: waiting" label AND comment must be
-# after the trigger_time stored in the HQ comment (prevents stale skip comments
-# posted at PR open from being misinterpreted as responses to review requests).
+# Fires on every issue_comment from coderabbitai[bot], created OR edited.
+# CR communicates rate-limit state by EDITING its existing summary comment
+# (not by posting a new one), so we must listen for `edited` too.
+#
+# Guards: PR must have "coderabbit: waiting" label AND the comment's effective
+# timestamp (updated_at) must be after the trigger_time stored in the HQ comment
+# (prevents stale comments posted at PR open from being misinterpreted as
+# responses to the current review request).
 #
 # Branches:
 #   - Skip detected → complete
@@ -12,7 +16,7 @@ name: Bot — CR Watch
 
 on:
   issue_comment:
-    types: [created]
+    types: [created, edited]
 
 jobs:
   watch:
@@ -49,7 +53,10 @@ jobs:
             const pr_number = context.issue.number;
             const comment = context.payload.comment;
             const commentBody = comment.body || '';
-            const commentCreatedAt = comment.created_at;
+            // Effective timestamp: for an edit, updated_at is when CR changed the
+            // comment (e.g. flipped it to rate-limited). For a fresh create,
+            // updated_at === created_at. Either way this is the moment that matters.
+            const commentEffectiveAt = comment.updated_at ?? comment.created_at;
 
             // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
             // Remove this block when promoting to main.
@@ -87,8 +94,8 @@ jobs:
               triggerTime = m?.[1]?.trim() || null;
             }
 
-            if (triggerTime && new Date(commentCreatedAt) < new Date(triggerTime)) {
-              core.info(`Comment at ${commentCreatedAt} is before trigger_time ${triggerTime} — ignoring stale comment.`);
+            if (triggerTime && new Date(commentEffectiveAt) < new Date(triggerTime)) {
+              core.info(`Comment effective at ${commentEffectiveAt} is before trigger_time ${triggerTime} — ignoring stale comment.`);
               return;
             }
 
@@ -158,9 +165,10 @@ jobs:
             if (isRateLimitComment(commentBody)) {
               core.info('Rate-limit comment detected — scheduling retry.');
 
-              // Parse delay anchored to when CR posted the comment.
-              // We only fire on `created` events so created_at is the right anchor.
-              const anchorIso = comment.created_at;
+              // Parse delay anchored to when CR last touched the comment. For an
+              // edit (CR flipping its summary to rate-limited), updated_at is when
+              // the limit was actually issued — created_at would be stale.
+              const anchorIso = commentEffectiveAt;
               const delaySecs = computeRateLimitDelay(commentBody, anchorIso, Date.now());
 
               // Determine review_type from HQ comment checkbox state


### PR DESCRIPTION
## The bug

When CodeRabbit rate-limits a *triggered* review, it doesn't post a new comment — it **edits its existing summary comment in place** to show "Review limit reached · available in N minutes" (confirmed via the comment's edit history).

`bot-cr-watch` only listened for `issue_comment.created`, so it never saw the edit. The 4 stuck test PRs (#231, #232, #233 + more) sat in `waiting` indefinitely because the rate-limit signal arrived as an edit we ignored.

## The fix

1. **Listen for `edited`** in addition to `created`.
2. **Use `updated_at` as the effective timestamp** (was `created_at`) — for an edit, `updated_at` is when CR actually issued the limit; `created_at` is the stale PR-open time. This applies to both:
   - the `trigger_time` staleness guard (otherwise an edited comment whose `created_at` predates the trigger would be wrongly rejected)
   - the rate-limit delay anchor passed to `computeRateLimitDelay`

## Safety

- No infinite loop: trigger is gated on `comment.user.login == 'coderabbitai[bot]'`, and the bot only ever edits the *separate* HQ comment (authored by `rickcedwhat-ai`).
- Extra invocations from CR editing its walkthrough during normal reviews are harmless — they fall through to "not a skip or rate-limit — ignoring."

🤖 Generated with [Claude Code](https://claude.com/claude-code)