### PR TITLE
fix(bot): forward BOT_PAT auth to GitHub dispatch via QStash

### DIFF
--- a/.github/workflows/bot-cr-trigger.yml
+++ b/.github/workflows/bot-cr-trigger.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT: ${{ secrets.BOT_PAT }}
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
@@ -173,6 +174,8 @@ jobs:
                     headers: {
                       'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
                       'Upstash-Delay': `${remainingSecs}s`,
+                      'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
+                      'Upstash-Forward-Content-Type': 'application/json',
                       'Content-Type': 'application/json',
                     },
                     body: payload,

--- a/.github/workflows/bot-cr-watch.yml
+++ b/.github/workflows/bot-cr-watch.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           QSTASH_TOKEN: ${{ secrets.QSTASH_TOKEN }}
+          BOT_PAT: ${{ secrets.BOT_PAT }}
         with:
           github-token: ${{ secrets.BOT_PAT }}
           script: |
@@ -192,6 +193,8 @@ jobs:
                   headers: {
                     'Authorization': `Bearer ${process.env.QSTASH_TOKEN}`,
                     'Upstash-Delay': `${delaySecs}s`,
+                    'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
+                    'Upstash-Forward-Content-Type': 'application/json',
                     'Content-Type': 'application/json',
                   },
                   body: payload,


### PR DESCRIPTION
## The bug — why all 5 test PRs sat in `rate-limited` for 4+ hours

QStash publishes the retry to GitHub's `repository_dispatch` API (`/repos/OWNER/REPO/dispatches`), which **requires authentication**. Both `bot-cr-trigger` and `bot-cr-watch` published the QStash message but never set `Upstash-Forward-Authorization`. So QStash dutifully POSTed to GitHub's dispatch endpoint with **no credentials** → GitHub returned 401 → no `repository_dispatch` event ever fired → `bot-cr-retry` has **zero runs**.

The failure was invisible because QStash *accepted* the publish and returned real message IDs (which we displayed in the HQ comment), so everything looked healthy right up until the retry silently 401'd hours later.

## The fix

Add the two forward headers the old `bot-listener` used:
```js
'Upstash-Forward-Authorization': `Bearer ${process.env.BOT_PAT}`,
'Upstash-Forward-Content-Type': 'application/json',
```
QStash strips the `Upstash-Forward-` prefix and applies them to the forwarded GitHub request. Also exposed `BOT_PAT` as an env var in both steps (previously only passed as `github-token`, not available to `process.env`).

## Note on the 5 stuck PRs

Their existing QStash messages already fired and 401'd — they won't auto-recover. But their rate-limit windows expired hours ago, so a fresh trigger will just get reviewed normally. We'll re-trigger after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication credential handling in automated bot workflows to ensure secure and properly authenticated operations.

* **Chores**
  * Updated workflow configuration to strengthen credential management in automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->