### PR TITLE
feat(bot): guide user to re-review (not just resolve threads) to clear unresolved

### DIFF
--- a/.github/workflows/bot-cr-complete.yml
+++ b/.github/workflows/bot-cr-complete.yml
@@ -237,5 +237,11 @@ jobs:
 
             await swapLabel('coderabbit: unresolved');
             await setStatus('failure', 'CodeRabbit review has actionable comments');
-            await writeCRSection('> ❌ Review complete · actionable comments to resolve before merge', true);
+            await writeCRSection(
+              '> ❌ Review complete · actionable comments to resolve\n' +
+              '>\n' +
+              "> ℹ️ After addressing them, re-trigger a review (re-check **Full review** above). " +
+              "Resolving threads alone won't unblock the merge — CodeRabbit must re-review and approve.",
+              true,
+            );
             core.info(`${actionableCount} actionable / ${inlineThreads.length} open thread(s) → coderabbit: unresolved`);


### PR DESCRIPTION
One-line HQ copy change. When a PR is `unresolved`, the note now explains that CodeRabbit's formal review decision only clears on a fresh review — resolving threads alone leaves the merge blocked (the confusion we hit on #249). Tells you to re-check **Full review** after addressing comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced code review feedback messages to provide clearer guidance when actionable comments remain unresolved, including instructions for resolving issues and re-triggering the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->