### PR TITLE
fix(docs): make hero code cards horizontally scrollable on mobile

### DIFF
--- a/docs/.vitepress/theme/components/HomepageHero.vue
+++ b/docs/.vitepress/theme/components/HomepageHero.vue
@@ -97,16 +97,12 @@ const EXAMPLES = '/playwright-smart-table/examples/'
 
 /* The card — border / glow / background live here so equal-height is controllable */
 .hp-card {
-  flex: 1 1 auto;
-  min-height: 0;
   min-width: 0;
-  display: flex;
   border-radius: 14px;
   overflow: hidden;
 }
 .hp-card :deep(div[class*='language-']) {
-  width: 100%;
-  display: flex;
+  min-width: 0;
   margin: 0 !important;
   padding: 0 !important;
   background: transparent !important;
@@ -114,10 +110,6 @@ const EXAMPLES = '/playwright-smart-table/examples/'
   box-shadow: none !important;
 }
 .hp-card :deep(div[class*='language-'] pre) {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
   padding: 22px 0 !important;
   margin: 0 !important;
   background: transparent !important;


### PR DESCRIPTION
The homepage hero's Before/After code cards clipped long lines on mobile instead of scrolling — unlike the doc code blocks, which scroll fine.

**Cause:** the cards wrapped the code in nested flex containers (the `pre` was a flex column with `justify-content: center` for vertical centering). In a flex column the `code` element gets sized to the container width, so overflowing lines never registered as scrollable content — they just clipped under the card's `overflow: hidden`.

**Fix:** that vertical centering was only needed for the old side-by-side equal-height layout. The cards are stacked now, so it does nothing visually — removed it. The `pre` is a plain block again with `overflow-x: auto`, matching the doc code blocks exactly.

## Test plan
- [x] Narrow viewport — hero cards scroll horizontally
- [x] Desktop — no visual change (cards size to content as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)