### PR TITLE
fix(bot): pad empty state values to prevent Queue Issue corruption

### DIFF
--- a/.github/scripts/bot-queue.mjs
+++ b/.github/scripts/bot-queue.mjs
@@ -73,12 +73,15 @@ export function parseQueueState(issueBody) {
 export function serializeQueueState(state) {
   const nowMs = Date.now();
 
+  // Pad empty values with a space so GitHub doesn't strip trailing whitespace
+  // and corrupt the next-line key when the issue body is round-tripped via API.
+  const pad = (v) => (v === '' || v == null) ? ' ' : String(v);
   const stateBlock = [
     '<!-- cr-queue-state',
     `tokens: ${state.tokens}`,
-    `last_decremented_at: ${state.last_decremented_at}`,
-    `refill_qstash_id: ${state.refill_qstash_id}`,
-    `refill_at: ${state.refill_at}`,
+    `last_decremented_at: ${pad(state.last_decremented_at)}`,
+    `refill_qstash_id: ${pad(state.refill_qstash_id)}`,
+    `refill_at: ${pad(state.refill_at)}`,
     `priority: ${JSON.stringify(state.priority)}`,
     `normal: ${JSON.stringify(state.normal)}`,
     `backburner: ${JSON.stringify(state.backburner)}`,


### PR DESCRIPTION
## The bug

After #260 merged, the Queue Issue state was being corrupted on every write. When `refill_qstash_id` and `refill_at` are empty strings, `serializeQueueState` produces:

```
refill_qstash_id: 
refill_at: 
```

GitHub's API strips trailing whitespace from issue body lines on save. On the next read, the stripped lines run together into:

```
refill_qstash_id: refill_at:
refill_at: priority: []
```

The parser's `^key:\s*(.*)$` regex then reads `refill_qstash_id` = `"refill_at:"` and `refill_at` = `"priority: []"`, corrupting the state. This caused PR #264's re-queue to the coordinator to silently fail — the label was set to `coderabbit: queued` but the Queue Issue showed empty queues.

## The fix

Pad empty string values with a single space so GitHub doesn't strip the line:

```js
const pad = (v) => (v === '' || v == null) ? ' ' : String(v);
```

The parser's `.trim()` call handles the trailing space on read, so round-trips are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal queue state serialization for better data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->