### PR TITLE
feat(bot): promote coordinator to main — remove TEST GUARDs, two-table dashboard

### DIFF
--- a/.github/scripts/bot-queue.mjs
+++ b/.github/scripts/bot-queue.mjs
@@ -82,9 +82,10 @@ export function parseQueueState(issueBody) {
  *           refill_at: string, priority: Array, normal: Array, backburner: Array,
  *           reviews_this_session: number }} state
  * @param {{ inReview?: number, unresolved?: number }} [counts]
+ * @param {Array<{ pr: number, title: string, status: string, updated: string }>} [liveItems]
  * @returns {string}
  */
-export function serializeQueueState(state, { inReview = 0, unresolved = 0 } = {}) {
+export function serializeQueueState(state, { inReview = 0, unresolved = 0 } = {}, liveItems = []) {
   const nowMs = Date.now();
 
   // Use '-' for empty string values. GitHub strips trailing whitespace from
@@ -125,44 +126,94 @@ export function serializeQueueState(state, { inReview = 0, unresolved = 0 } = {}
   const queuedCount = state.priority.length + state.normal.length + state.backburner.length;
   const statsLine = `📊 ${queuedCount} queued · ${inReview} in review · ${unresolved} unresolved · ${state.reviews_this_session || 0} reviews this session`;
 
-  const buildTable = (items, label) => {
-    const lines = [];
-    lines.push(`### ${label}`);
-    if (items.length === 0) {
-      lines.push('| PR | Title | Queued |');
-      lines.push('|---|---|---|');
-      lines.push('| — | _empty_ | — |');
+  // ── Queue table: all queued PRs in trigger order with Level column ────────
+
+  const safeTitle = (t) => String(t ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|');
+
+  const LEVEL_ICON = { priority: '🔴 Priority', normal: '🟡 Normal', backburner: '⬜ Backburner' };
+
+  const buildQueueTable = () => {
+    const lines = ['### 📋 Review Queue'];
+    lines.push('| Level | PR | Title | Queued |');
+    lines.push('|---|---|---|---|');
+    const allQueued = [
+      ...state.priority.map(item => ({ ...item, level: 'priority' })),
+      ...state.normal.map(item => ({ ...item, level: 'normal' })),
+      ...state.backburner.map(item => ({ ...item, level: 'backburner' })),
+    ];
+    if (allQueued.length === 0) {
+      lines.push('| — | _empty_ | — | — |');
     } else {
-      lines.push('| PR | Title | Queued |');
-      lines.push('|---|---|---|');
-      for (const item of items) {
-        // Escape backslashes first, then pipes, and strip newlines so titles
-        // don't break the markdown table (CodeQL: complete the escape sequence).
-        const safeTitle = String(item.title ?? '')
-          .replace(/\r?\n/g, ' ')
-          .replace(/\\/g, '\\\\')
-          .replace(/\|/g, '\\|');
-        lines.push(`| #${item.pr} | ${safeTitle} | ${formatRelativeTime(item.queued_at, nowMs)} |`);
+      for (const item of allQueued) {
+        lines.push(`| ${LEVEL_ICON[item.level]} | #${item.pr} | ${safeTitle(item.title)} | ${formatRelativeTime(item.queued_at, nowMs)} |`);
       }
     }
     return lines.join('\n');
   };
 
-  const body = [
+  // ── Live table: open PRs not in queue, sorted by status urgency ──────────
+
+  const STATUS_ICON = {
+    'coderabbit: waiting':     '⏳ Waiting',
+    'coderabbit: unresolved':  '❌ Unresolved',
+    'coderabbit: complete':    '✅ Complete',
+    'coderabbit: not started': '🔲 Not started',
+  };
+
+  // Status sort order: waiting → unresolved → complete → not started
+  const STATUS_ORDER = {
+    'coderabbit: waiting':     0,
+    'coderabbit: unresolved':  1,
+    'coderabbit: complete':    2,
+    'coderabbit: not started': 3,
+  };
+
+  const THREE_DAYS_MS = 3 * 86_400_000;
+
+  const buildLiveTable = (items) => {
+    if (!items || items.length === 0) return null;
+    const sorted = [...items].sort((a, b) => {
+      const ao = STATUS_ORDER[a.status] ?? 99;
+      const bo = STATUS_ORDER[b.status] ?? 99;
+      return ao - bo;
+    });
+    const lines = ['### 🔍 Active PRs'];
+    lines.push('| Status | PR | Title | Updated |');
+    lines.push('|---|---|---|---|');
+    for (const item of sorted) {
+      let icon = STATUS_ICON[item.status] ?? item.status;
+      // Aging warning: unresolved + updated_at > 3 days ago
+      if (item.status === 'coderabbit: unresolved' && item.updated) {
+        const updMs = new Date(item.updated).getTime();
+        if (!isNaN(updMs) && (nowMs - updMs) > THREE_DAYS_MS) {
+          icon = `⚠️ Unresolved`;
+        }
+      }
+      lines.push(`| ${icon} | #${item.pr} | ${safeTitle(item.title)} | ${formatRelativeTime(item.updated, nowMs)} |`);
+    }
+    return lines.join('\n');
+  };
+
+  const liveTable = buildLiveTable(liveItems);
+
+  const parts = [
     stateBlock,
     '',
     '## 🐰 CodeRabbit Review Queue',
     bucketLine,
     statsLine,
     '',
-    buildTable(state.priority, '🔴 Priority'),
-    '',
-    buildTable(state.normal, '🟡 Normal'),
-    '',
-    buildTable(state.backburner, '⬜ Backburner _(triggers only when bucket is full)_'),
-  ].join('\n');
+    buildQueueTable(),
+  ];
 
-  return body;
+  if (liveTable) {
+    parts.push('', liveTable);
+  }
+
+  return parts.join('\n');
 }
 
 /**

--- a/.github/workflows/bot-cr-complete.yml
+++ b/.github/workflows/bot-cr-complete.yml
@@ -51,14 +51,6 @@ jobs:
             const submittedAt = review.submitted_at;
             const reviewBody = review.body ?? '';
 
-            // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
-            // Remove this block when promoting to main.
-            const baseBranch = context.payload.pull_request.base.ref;
-            if (baseBranch !== 'coderabbit') {
-              core.info(`PR #${pr_number} targets "${baseBranch}", not "coderabbit" — skipping (test guard).`);
-              return;
-            }
-
             // ── guard: PR must have "coderabbit: waiting" label ───────────────
 
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({

--- a/.github/workflows/bot-cr-coordinator.yml
+++ b/.github/workflows/bot-cr-coordinator.yml
@@ -79,11 +79,14 @@ jobs:
             });
             let waitingCount = 0;
             let unresolvedCount = 0;
+            // Collect label data for all PRs (used for migration and liveItems)
+            const prLabelMap = new Map();
             for (const pr of allPRs) {
               const { data: labelData } = await github.rest.issues.listLabelsOnIssue({
                 owner, repo, issue_number: pr.number,
               });
               const labelNames = labelData.map(l => l.name);
+              prLabelMap.set(pr.number, labelNames);
               if (labelNames.includes('coderabbit: waiting')) waitingCount++;
               if (labelNames.includes('coderabbit: unresolved')) unresolvedCount++;
               if (!labelNames.includes('coderabbit: rate-limited')) continue;
@@ -98,6 +101,25 @@ jobs:
                 title: pr.title,
                 queued_at: nowIso,
               }, 'normal');
+            }
+
+            // Build liveItems after migration so queue membership is final
+            const liveItems = [];
+            for (const pr of allPRs) {
+              const inQueue = [...state.priority, ...state.normal, ...state.backburner]
+                .some(item => item.pr === pr.number);
+              if (!inQueue) {
+                const labelNames = prLabelMap.get(pr.number) ?? [];
+                const crStatus = labelNames.find(n => n.startsWith('coderabbit:'));
+                if (crStatus) {
+                  liveItems.push({
+                    pr: pr.number,
+                    title: pr.title,
+                    status: crStatus,
+                    updated: pr.updated_at,
+                  });
+                }
+              }
             }
 
             // ── Check if anything to do ───────────────────────────────────────
@@ -131,23 +153,6 @@ jobs:
               state.refill_at = '';
               await writeState(state);
               return;
-            }
-
-            // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
-            // Remove this block when promoting to main.
-            try {
-              const { data: prData } = await github.rest.pulls.get({
-                owner, repo, pull_number: next.pr,
-              });
-              if (prData.base.ref !== 'coderabbit') {
-                core.info(`PR #${next.pr} targets "${prData.base.ref}", not "coderabbit" — skipping (test guard).`);
-                // Remove from queue to avoid infinite loop
-                state = dequeue(state, next.pr);
-                await writeState(state);
-                return;
-              }
-            } catch (err) {
-              core.warning(`Could not check PR #${next.pr} base branch: ${err.message}`);
             }
 
             // ── Trigger review ────────────────────────────────────────────────
@@ -285,7 +290,7 @@ jobs:
               const { serializeQueueState: ser } = await import(
                 `file://${path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/bot-queue.mjs')}`
               );
-              const newBody = ser(s, { inReview: waitingCount, unresolved: unresolvedCount });
+              const newBody = ser(s, { inReview: waitingCount, unresolved: unresolvedCount }, liveItems);
               await github.rest.issues.update({
                 owner, repo, issue_number: queueIssue.number, body: newBody,
               });

--- a/.github/workflows/bot-cr-coordinator.yml
+++ b/.github/workflows/bot-cr-coordinator.yml
@@ -194,9 +194,16 @@ jobs:
               owner, repo, issue_number: next.pr, labels: ['coderabbit: waiting'],
             });
 
-            // Update live counts to reflect the label change just made
-            // (the PR moved from queued → waiting, so increment waitingCount)
+            // Update live counts and live table to reflect the label change.
+            // The triggered PR moved from queue → waiting, so it now belongs
+            // in the live table rather than the queue table.
             waitingCount++;
+            liveItems.push({
+              pr: next.pr,
+              title: next.title,
+              status: 'coderabbit: waiting',
+              updated: nowIso,
+            });
 
             // Decrement tokens
             state.tokens = Math.max(0, state.tokens - 1);

--- a/.github/workflows/bot-cr-init.yml
+++ b/.github/workflows/bot-cr-init.yml
@@ -7,7 +7,6 @@ name: Bot — CR Init
 on:
   pull_request:
     types: [opened]
-    branches: [coderabbit]  # TEST GUARD — remove when promoting to main
 
 jobs:
   init:

--- a/.github/workflows/bot-cr-sync.yml
+++ b/.github/workflows/bot-cr-sync.yml
@@ -18,7 +18,6 @@ name: Bot — CR Sync
 on:
   pull_request:
     types: [synchronize]
-    branches: [coderabbit]  # TEST GUARD — remove when promoting to main
 
 jobs:
   sync:

--- a/.github/workflows/bot-cr-trigger.yml
+++ b/.github/workflows/bot-cr-trigger.yml
@@ -128,15 +128,11 @@ jobs:
 
             core.info(`Review type: ${reviewType}, priority level: ${priorityLevel}`);
 
-            // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
-            // Remove this block when promoting to main.
+            // ── fetch PR data ─────────────────────────────────────────────────
+
             const { data: prData } = await github.rest.pulls.get({
               owner, repo, pull_number: pr_number,
             });
-            if (prData.base.ref !== 'coderabbit') {
-              core.info(`PR #${pr_number} targets "${prData.base.ref}", not "coderabbit" — skipping (test guard).`);
-              return;
-            }
 
             // ── find HQ comment ───────────────────────────────────────────────
 

--- a/.github/workflows/bot-cr-watch.yml
+++ b/.github/workflows/bot-cr-watch.yml
@@ -72,15 +72,11 @@ jobs:
             const nowMs = Date.now();
             const nowIso = new Date(nowMs).toISOString();
 
-            // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
-            // Remove this block when promoting to main.
+            // ── fetch PR data ─────────────────────────────────────────────────
+
             const { data: prData } = await github.rest.pulls.get({
               owner, repo, pull_number: pr_number,
             });
-            if (prData.base.ref !== 'coderabbit') {
-              core.info(`PR #${pr_number} targets "${prData.base.ref}", not "coderabbit" — skipping (test guard).`);
-              return;
-            }
 
             // ── guard: PR must have "coderabbit: waiting" label ───────────────
 

--- a/tests/unit/bot/bot-queue.test.ts
+++ b/tests/unit/bot/bot-queue.test.ts
@@ -567,6 +567,203 @@ describe('serializeQueueState — stats line', () => {
   });
 });
 
+// ── serializeQueueState — two-table dashboard ────────────────────────────────
+
+describe('serializeQueueState — two-table dashboard', () => {
+  it('queue table shows all three tiers in order with Level column', () => {
+    const state = {
+      tokens: 2,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [makePR(261, 'feat: auth')],
+      normal: [makePR(258, 'fix: bug')],
+      backburner: [makePR(214, 'chore: deps')],
+      reviews_this_session: 0,
+    };
+    const body = serializeQueueState(state);
+    // Queue table header
+    expect(body).toContain('### 📋 Review Queue');
+    expect(body).toContain('| Level | PR | Title | Queued |');
+    // All three entries present with level icons
+    expect(body).toContain('🔴 Priority');
+    expect(body).toContain('#261');
+    expect(body).toContain('🟡 Normal');
+    expect(body).toContain('#258');
+    expect(body).toContain('⬜ Backburner');
+    expect(body).toContain('#214');
+    // Priority appears before normal, normal before backburner
+    const priorityIdx = body.indexOf('#261');
+    const normalIdx = body.indexOf('#258');
+    const backburnerIdx = body.indexOf('#214');
+    expect(priorityIdx).toBeLessThan(normalIdx);
+    expect(normalIdx).toBeLessThan(backburnerIdx);
+  });
+
+  it('queue table shows empty row when all queues empty', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const body = serializeQueueState(state);
+    expect(body).toContain('### 📋 Review Queue');
+    expect(body).toContain('| — | _empty_ | — | — |');
+  });
+
+  it('live table appears when liveItems provided', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const liveItems = [
+      { pr: 264, title: 'test: parseNumber', status: 'coderabbit: waiting', updated: ISO },
+    ];
+    const body = serializeQueueState(state, {}, liveItems);
+    expect(body).toContain('### 🔍 Active PRs');
+    expect(body).toContain('#264');
+    expect(body).toContain('⏳ Waiting');
+  });
+
+  it('live table omitted when liveItems is empty', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const body = serializeQueueState(state, {}, []);
+    expect(body).not.toContain('### 🔍 Active PRs');
+  });
+
+  it('live table omitted when liveItems not passed', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const body = serializeQueueState(state);
+    expect(body).not.toContain('### 🔍 Active PRs');
+  });
+
+  it('status icons map correctly for all four statuses', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const liveItems = [
+      { pr: 1, title: 'waiting PR',     status: 'coderabbit: waiting',     updated: ISO },
+      { pr: 2, title: 'unresolved PR',  status: 'coderabbit: unresolved',  updated: ISO },
+      { pr: 3, title: 'complete PR',    status: 'coderabbit: complete',    updated: ISO },
+      { pr: 4, title: 'not started PR', status: 'coderabbit: not started', updated: ISO },
+    ];
+    const body = serializeQueueState(state, {}, liveItems);
+    expect(body).toContain('⏳ Waiting');
+    expect(body).toContain('❌ Unresolved');
+    expect(body).toContain('✅ Complete');
+    expect(body).toContain('🔲 Not started');
+  });
+
+  it('live table sorted by status urgency: waiting → unresolved → complete → not started', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const liveItems = [
+      { pr: 10, title: 'not started PR', status: 'coderabbit: not started', updated: ISO },
+      { pr: 11, title: 'complete PR',    status: 'coderabbit: complete',    updated: ISO },
+      { pr: 12, title: 'unresolved PR',  status: 'coderabbit: unresolved',  updated: ISO },
+      { pr: 13, title: 'waiting PR',     status: 'coderabbit: waiting',     updated: ISO },
+    ];
+    const body = serializeQueueState(state, {}, liveItems);
+    const waitingIdx    = body.indexOf('#13');
+    const unresolvedIdx = body.indexOf('#12');
+    const completeIdx   = body.indexOf('#11');
+    const notStartedIdx = body.indexOf('#10');
+    expect(waitingIdx).toBeLessThan(unresolvedIdx);
+    expect(unresolvedIdx).toBeLessThan(completeIdx);
+    expect(completeIdx).toBeLessThan(notStartedIdx);
+  });
+
+  it('aging warning (⚠️) appears for unresolved PRs older than 3 days', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    const oldIso = new Date(NOW - 4 * 86_400_000).toISOString(); // 4 days ago
+    const recentIso = new Date(NOW - 1 * 86_400_000).toISOString(); // 1 day ago
+    const liveItems = [
+      { pr: 20, title: 'old unresolved', status: 'coderabbit: unresolved', updated: oldIso },
+      { pr: 21, title: 'new unresolved', status: 'coderabbit: unresolved', updated: recentIso },
+    ];
+    const body = serializeQueueState(state, {}, liveItems);
+    // Old one should have warning prefix
+    expect(body).toContain('⚠️ Unresolved');
+    // New one should have regular icon (but ❌ Unresolved)
+    expect(body).toContain('❌ Unresolved');
+  });
+
+  it('no aging warning for unresolved PRs less than 3 days old', () => {
+    const state = {
+      tokens: 3,
+      last_decremented_at: '',
+      refill_qstash_id: '',
+      refill_at: '',
+      priority: [],
+      normal: [],
+      backburner: [],
+      reviews_this_session: 0,
+    };
+    // 1 day ago — well under the 3-day threshold
+    const recentIso = new Date(NOW - 1 * 86_400_000).toISOString();
+    const liveItems = [
+      { pr: 30, title: 'recent unresolved', status: 'coderabbit: unresolved', updated: recentIso },
+    ];
+    const body = serializeQueueState(state, {}, liveItems);
+    // Less than 3 days: no aging warning
+    expect(body).not.toContain('⚠️ Unresolved');
+    expect(body).toContain('❌ Unresolved');
+  });
+});
+
 // ── incrementReviewsThisSession ───────────────────────────────────────────────
 
 describe('incrementReviewsThisSession', () => {


### PR DESCRIPTION
## What

Removes all `base.ref === 'coderabbit'` TEST GUARDs from every bot workflow, making the CR queue coordinator live on real PRs against `main`. Also adds the two-table dashboard to the Queue Issue.

## Guard removal

All TEST GUARDs removed from:
- `bot-cr-init.yml` / `bot-cr-sync.yml` — `branches: [coderabbit]` filter removed
- `bot-cr-trigger.yml` / `bot-cr-watch.yml` / `bot-cr-complete.yml` — `if (base.ref !== 'coderabbit')` early-returns removed
- `bot-cr-coordinator.yml` — the try/catch guard that skipped non-coderabbit PRs removed

The system now handles all open PRs regardless of base branch.

## Two-table Queue Issue dashboard

**📋 Review Queue** — all queued PRs in trigger order with Level column:
```
| Level | PR | Title | Queued |
|---|---|---|---|
| 🔴 Priority | #261 | feat: auth | 14m ago |
| 🟡 Normal | #258 | fix: bug | 8m ago |
| ⬜ Backburner | #214 | chore: deps | 2d ago |
```

**🔍 Active PRs** — all open PRs not in queue, sorted waiting → unresolved → complete → not started. Aging warning (⚠️) for unresolved PRs >3 days. Omitted when empty:
```
| Status | PR | Title | Updated |
|---|---|---|---|
| ⏳ Waiting | #264 | test: parseNumber | 5m ago |
| ⚠️ Unresolved | #263 | test: range | 4d ago |
| ✅ Complete | #259 | fix: clamp | 3h ago |
```

**9 new unit tests** — 320 total, all passing.

## After merging

Run `bot-cr-queue-init` via workflow_dispatch once to ensure the Queue Issue body is in the new two-table format. Then the bot is fully live on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR queue now displays a unified dashboard view combining review queue and active PRs with status indicators.
  * Added visual aging warning for unresolved PRs not updated within 3 days.

* **Improvements**
  * Bot workflows now apply consistently to all branches.

* **Tests**
  * Added comprehensive test coverage for queue dashboard rendering and status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->