### PR TITLE
fix(bot): handle missing changes.body.from in checkbox trigger

### DIFF
--- a/.github/workflows/bot-cr-trigger.yml
+++ b/.github/workflows/bot-cr-trigger.yml
@@ -46,19 +46,34 @@ jobs:
 
             let reviewType = null; // 'full' | 'incremental' | null
 
-            // Checkbox toggle in the HQ comment (edited event, human unchecked → checked)
+            // Checkbox toggle in the HQ comment (edited event, human checked a box)
             if (action === 'edited' &&
                 commentAuthor === 'rickcedwhat-ai' &&
                 context.payload.sender?.login !== 'rickcedwhat-ai' &&
                 commentBody.includes('<!-- bot-hq -->')) {
               const oldBody = context.payload.changes?.body?.from ?? '';
-              const wasFullUnchecked   = /- \[ \] Full review/i.test(oldBody);
-              const wasIncrUnchecked   = /- \[ \] Incremental review/i.test(oldBody);
-              const isFullChecked      = /- \[x\] Full review/i.test(commentBody);
-              const isIncrChecked      = /- \[x\] Incremental review/i.test(commentBody);
+              // GitHub's task-list checkbox click often omits changes.body.from
+              // (empty string). When that happens we can't check "was it unchecked
+              // before" — so fall back to "is it checked now?" as the signal.
+              // The sender guard above already ensures only humans trigger this.
+              const oldBodyAvailable = oldBody.length > 0;
+              const wasRedUnchecked    = !oldBodyAvailable || /- \[ \] 🔴/u.test(oldBody);
+              const wasYellowUnchecked = !oldBodyAvailable || /- \[ \] 🟡/u.test(oldBody);
+              const wasWhiteUnchecked  = !oldBodyAvailable || /- \[ \] ⬜/u.test(oldBody);
+              const wasFullUnchecked   = !oldBodyAvailable || /- \[ \] Full review/i.test(oldBody);
+              const wasIncrUnchecked   = !oldBodyAvailable || /- \[ \] Incremental review/i.test(oldBody);
 
-              if (wasFullUnchecked && isFullChecked)   reviewType = 'full';
-              else if (wasIncrUnchecked && isIncrChecked) reviewType = 'incremental';
+              const isRedChecked    = /- \[x\] 🔴/u.test(commentBody);
+              const isYellowChecked = /- \[x\] 🟡/u.test(commentBody);
+              const isWhiteChecked  = /- \[x\] ⬜/u.test(commentBody);
+              const isFullChecked   = /- \[x\] Full review/i.test(commentBody);
+              const isIncrChecked   = /- \[x\] Incremental review/i.test(commentBody);
+
+              if      (wasRedUnchecked    && isRedChecked)    reviewType = 'full'; // priority
+              else if (wasYellowUnchecked && isYellowChecked) reviewType = 'full'; // normal
+              else if (wasWhiteUnchecked  && isWhiteChecked)  reviewType = 'full'; // backburner
+              else if (wasFullUnchecked   && isFullChecked)   reviewType = 'full'; // legacy
+              else if (wasIncrUnchecked   && isIncrChecked)   reviewType = 'incremental'; // legacy
             }
 
             // Text command: @rickcedwhat-ai review / @rickcedwhat-ai review incremental
@@ -75,16 +90,6 @@ jobs:
             }
 
             core.info(`Review type: ${reviewType}`);
-
-            // ── TEST GUARD: only act on PRs targeting the coderabbit branch ───
-            // Remove this block when promoting to main.
-            const { data: prData } = await github.rest.pulls.get({
-              owner, repo, pull_number: pr_number,
-            });
-            if (prData.base.ref !== 'coderabbit') {
-              core.info(`PR #${pr_number} targets "${prData.base.ref}", not "coderabbit" — skipping (test guard).`);
-              return;
-            }
 
             // ── find HQ comment ───────────────────────────────────────────────
 


### PR DESCRIPTION
GitHub's task-list checkbox UI sends `issue_comment.edited` events **without** `changes.body.from`— it uses a different API path for task list toggles. This caused `wasXxxUnchecked` to always be `false` (tested against `''`), so every checkbox click said `No CR trigger detected`.

**Fix:** when `oldBody` is empty, treat `wasXxxUnchecked = true` (fall back to checking the current state). The sender guard (`sender.login !== 'rickcedwhat-ai'`) already ensures only humans fire this path.

Also fixes two missing wiring issues: the 🔴/🟡/⬜ emoji checkboxes were never connected in this code path, and a stale `base.ref === 'coderabbit'` TEST GUARD was not removed by #268.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal PR review workflow automation to improve trigger detection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->