### PR TITLE
feat(worker): Cloudflare Worker for CR bot automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ playground/pst-unpack/
 
 # External (non-library) e2e tests — not part of CI, contain auth state
 /tests-external/
+worker/node_modules/

--- a/worker/package.json
+++ b/worker/package.json
@@ -10,8 +10,7 @@
   },
   "dependencies": {
     "hono": "^4.6.0",
-    "@upstash/redis": "^1.34.0",
-    "@upstash/qstash": "^2.7.0"
+    "@upstash/redis": "^1.34.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -9,8 +9,9 @@
     "cf-typegen": "wrangler types"
   },
   "dependencies": {
-    "hono": "^4.6.0",
-    "@upstash/redis": "^1.34.0"
+    "@upstash/qstash": "^2.11.0",
+    "@upstash/redis": "^1.34.0",
+    "hono": "^4.6.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241205.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "cr-bot",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "hono": "^4.6.0",
+    "@upstash/redis": "^1.34.0",
+    "@upstash/qstash": "^2.7.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241205.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/worker/src/handlers/coordinator.ts
+++ b/worker/src/handlers/coordinator.ts
@@ -3,7 +3,7 @@ import type { StateManager } from '../lib/state.js';
 import type { Env } from '../index.js';
 import type { QueueState } from '../lib/types.js';
 import { pickNextPR, dequeue, serializeQueueState, incrementReviewsThisSession } from '../lib/queue.js';
-import { isRateLimitComment } from '../lib/coderabbit.js';
+import { isRateLimitComment, computeRateLimitDelay } from '../lib/coderabbit.js';
 
 export interface CoordinatorContext {
   github: GitHubClient;
@@ -68,9 +68,14 @@ export async function handleCoordinator(ctx: CoordinatorContext): Promise<void> 
         .find(c => c.user.login === 'coderabbitai[bot]' && isRateLimitComment(c.body));
 
       if (rateLimitComment) {
-        const delaySecs = 0; // Already expired (coordinator was scheduled for after the delay)
+        // Compute actual remaining delay — only migrate if window has expired
+        const delaySecs = computeRateLimitDelay(
+          rateLimitComment.body,
+          rateLimitComment.created_at,
+          Date.now(),
+        );
         if (delaySecs <= 0) {
-          // Migrate to normal queue
+          // Rate-limit window has passed — migrate to normal queue
           const { enqueue: enqueueItem } = await import('../lib/queue.js');
           queueState = enqueueItem(
             queueState,
@@ -78,6 +83,7 @@ export async function handleCoordinator(ctx: CoordinatorContext): Promise<void> 
             'normal',
           );
         }
+        // else: still rate-limited — leave it; coordinator was fired too early
       }
     }
   } catch (err) {
@@ -121,8 +127,13 @@ export async function handleCoordinator(ctx: CoordinatorContext): Promise<void> 
     console.error(`Failed to update labels for PR #${next.pr}:`, err);
   }
 
-  // 7. Decrement token
-  await state.decrementToken();
+  // 7. Decrement token — refresh in-memory state to reflect the authoritative Redis value
+  const newTokens = await state.decrementToken();
+  queueState = {
+    ...queueState,
+    tokens: newTokens,
+    last_decremented_at: new Date().toISOString(),
+  };
 
   // 8. Dequeue PR from state
   queueState = dequeue(queueState, next.pr);

--- a/worker/src/handlers/coordinator.ts
+++ b/worker/src/handlers/coordinator.ts
@@ -1,0 +1,190 @@
+import type { GitHubClient } from '../lib/github.js';
+import type { StateManager } from '../lib/state.js';
+import type { Env } from '../index.js';
+import type { QueueState } from '../lib/types.js';
+import { pickNextPR, dequeue, serializeQueueState, incrementReviewsThisSession } from '../lib/queue.js';
+import { isRateLimitComment } from '../lib/coderabbit.js';
+
+export interface CoordinatorContext {
+  github: GitHubClient;
+  state: StateManager;
+  env: Env;
+}
+
+const CR_CONTEXT = 'coderabbit-review';
+
+export async function scheduleCoordinator(
+  qstashToken: string,
+  delaySecs: number,
+  workerUrl: string,
+): Promise<string | null> {
+  const url = `https://qstash.upstash.io/v2/publish/${workerUrl}/coordinator`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${qstashToken}`,
+        'Content-Type': 'application/json',
+        'Upstash-Delay': `${delaySecs}s`,
+      },
+      body: JSON.stringify({ triggered_at: new Date().toISOString() }),
+    });
+    if (!res.ok) {
+      console.error(`QStash schedule failed: ${res.status}`);
+      return null;
+    }
+    const data = await res.json() as { messageId?: string };
+    return data.messageId ?? null;
+  } catch (err) {
+    console.error('QStash schedule error:', err);
+    return null;
+  }
+}
+
+export async function handleCoordinator(ctx: CoordinatorContext): Promise<void> {
+  const { github, state, env } = ctx;
+
+  // 1. Get state from Redis (includes lazy token refill)
+  let queueState = await state.getState();
+
+  // 2. Scan open PRs for rate-limited ones not in queue → migrate to normal queue
+  try {
+    const openPRs = await github.listOpenPRs();
+    const allQueued = new Set([
+      ...queueState.priority.map(p => p.pr),
+      ...queueState.normal.map(p => p.pr),
+      ...queueState.backburner.map(p => p.pr),
+    ]);
+
+    for (const pr of openPRs) {
+      if (allQueued.has(pr.number)) continue;
+      const labels = await github.getPRLabels(pr.number);
+      if (!labels.includes('coderabbit: rate-limited')) continue;
+
+      // Check if the rate-limit has expired by inspecting comments
+      const comments = await github.getIssueComments(pr.number);
+      const rateLimitComment = [...comments]
+        .reverse()
+        .find(c => c.user.login === 'coderabbitai[bot]' && isRateLimitComment(c.body));
+
+      if (rateLimitComment) {
+        const delaySecs = 0; // Already expired (coordinator was scheduled for after the delay)
+        if (delaySecs <= 0) {
+          // Migrate to normal queue
+          const { enqueue: enqueueItem } = await import('../lib/queue.js');
+          queueState = enqueueItem(
+            queueState,
+            { pr: pr.number, title: pr.title, queued_at: new Date().toISOString() },
+            'normal',
+          );
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Error scanning rate-limited PRs:', err);
+  }
+
+  // 3. If tokens=0 and queues non-empty → reschedule for 3600s and return
+  const totalQueued = queueState.priority.length + queueState.normal.length + queueState.backburner.length;
+  if (queueState.tokens === 0 && totalQueued > 0) {
+    const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
+    await scheduleCoordinator(env.QSTASH_TOKEN, 3600, workerUrl);
+    await state.saveState(queueState);
+    return;
+  }
+
+  // 4. Pick next PR
+  const next = pickNextPR(queueState);
+  if (!next) {
+    await state.saveState(queueState);
+    return;
+  }
+
+  // 5. Post @coderabbitai full review on the PR
+  try {
+    await github.createComment(next.pr, '@coderabbitai full review');
+  } catch (err) {
+    console.error(`Failed to post review comment on PR #${next.pr}:`, err);
+    await state.saveState(queueState);
+    return;
+  }
+
+  // 6. Swap label to waiting
+  try {
+    const pr = await github.getPR(next.pr);
+    await github.addLabels(next.pr, ['coderabbit: waiting']);
+    await github.setCommitStatus(pr.head.sha, 'pending', CR_CONTEXT, 'CodeRabbit review in progress');
+    // Remove queued label
+    await github.removeLabel(next.pr, 'coderabbit: queued').catch(() => {});
+    await github.removeLabel(next.pr, 'coderabbit: rate-limited').catch(() => {});
+  } catch (err) {
+    console.error(`Failed to update labels for PR #${next.pr}:`, err);
+  }
+
+  // 7. Decrement token
+  await state.decrementToken();
+
+  // 8. Dequeue PR from state
+  queueState = dequeue(queueState, next.pr);
+
+  // 9. Increment session reviews
+  queueState = incrementReviewsThisSession(queueState);
+
+  // 10. If queue still non-empty → schedule next QStash dispatch
+  const remainingQueued = queueState.priority.length + queueState.normal.length + queueState.backburner.length;
+  if (remainingQueued > 0) {
+    const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
+    const msgId = await scheduleCoordinator(env.QSTASH_TOKEN, 3600, workerUrl);
+    if (msgId) {
+      queueState = {
+        ...queueState,
+        refill_qstash_id: msgId,
+        refill_at: new Date(Date.now() + 3600 * 1000).toISOString(),
+      };
+    }
+  } else {
+    queueState = { ...queueState, refill_qstash_id: '', refill_at: '' };
+  }
+
+  // 11. Save state to Redis
+  await state.saveState(queueState);
+
+  // 12. Update Queue Issue dashboard
+  await updateQueueIssueDashboard(github, env, queueState);
+}
+
+async function updateQueueIssueDashboard(
+  github: GitHubClient,
+  env: Env,
+  queueState: QueueState,
+): Promise<void> {
+  const queueIssueNumber = parseInt(env.QUEUE_ISSUE_NUMBER, 10);
+  if (isNaN(queueIssueNumber)) return;
+
+  try {
+    // Gather live PR info
+    const openPRs = await github.listOpenPRs();
+    const liveItems: Array<{ pr: number; title: string; status: string; updated: string }> = [];
+
+    for (const pr of openPRs) {
+      const labels = await github.getPRLabels(pr.number).catch(() => [] as string[]);
+      const crLabel = labels.find(l => l.startsWith('coderabbit:'));
+      if (crLabel) {
+        liveItems.push({
+          pr: pr.number,
+          title: pr.title,
+          status: crLabel,
+          updated: pr.updated_at,
+        });
+      }
+    }
+
+    const inReview = liveItems.filter(i => i.status === 'coderabbit: waiting').length;
+    const unresolved = liveItems.filter(i => i.status === 'coderabbit: unresolved').length;
+
+    const newBody = serializeQueueState(queueState, { inReview, unresolved }, liveItems);
+    await github.updateIssue(queueIssueNumber, newBody);
+  } catch (err) {
+    console.error('Failed to update queue issue dashboard:', err);
+  }
+}

--- a/worker/src/handlers/webhook.ts
+++ b/worker/src/handlers/webhook.ts
@@ -207,10 +207,18 @@ async function triggerOrEnqueue(
       await github.updateComment(hq.id, updatedBody);
     }
 
-    // Schedule coordinator if not already scheduled
+    // Schedule coordinator if not already scheduled, and persist the messageId
     if (!newQueueState.refill_qstash_id) {
       const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
-      await scheduleCoordinator(env.QSTASH_TOKEN, 60, workerUrl);
+      const msgId = await scheduleCoordinator(env.QSTASH_TOKEN, 60, workerUrl);
+      if (msgId) {
+        const withSchedule = {
+          ...newQueueState,
+          refill_qstash_id: msgId,
+          refill_at: new Date(Date.now() + 60_000).toISOString(),
+        };
+        await state.saveState(withSchedule);
+      }
     }
   }
 }
@@ -241,9 +249,17 @@ export async function handlePullRequest(ctx: HandlerContext): Promise<void> {
 
   if (action === 'synchronize') {
     const labels = await github.getLabels(prNumber);
-    const isTerminal = labels.includes('coderabbit: complete') || labels.includes('coderabbit: unresolved');
+    // Reset on any non-trivial CR state — terminal (complete/unresolved) AND
+    // in-flight (waiting/queued/rate-limited). Only leave not-started alone.
+    const shouldReset = labels.some(l =>
+      l === 'coderabbit: complete' ||
+      l === 'coderabbit: unresolved' ||
+      l === 'coderabbit: waiting' ||
+      l === 'coderabbit: queued' ||
+      l === 'coderabbit: rate-limited',
+    );
 
-    if (isTerminal) {
+    if (shouldReset) {
       // Remove all CR labels, add not started
       await setExclusiveCRLabel(github, prNumber, 'coderabbit: not started', labels);
       await github.setCommitStatus(sha, 'pending', CR_CONTEXT, 'CodeRabbit review not yet requested');

--- a/worker/src/handlers/webhook.ts
+++ b/worker/src/handlers/webhook.ts
@@ -1,0 +1,374 @@
+import type { GitHubClient } from '../lib/github.js';
+import type { StateManager } from '../lib/state.js';
+import type { Env } from '../index.js';
+import type { QueueLevel } from '../lib/types.js';
+import {
+  isSkipComment,
+  isRateLimitComment,
+  computeRateLimitDelay,
+  parseActionableCount,
+  getCheckedLabel,
+  getPriorityFromCheckbox,
+  labelToStatus,
+} from '../lib/coderabbit.js';
+import { enqueue, dequeue, pickNextPR } from '../lib/queue.js';
+import { scheduleCoordinator } from './coordinator.js';
+
+export interface HandlerContext {
+  github: GitHubClient;
+  state: StateManager;
+  env: Env;
+  event: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  payload: any;
+}
+
+const BOT_LOGIN = 'rickcedwhat-ai';
+const CR_BOT_LOGIN = 'coderabbitai[bot]';
+const DEPENDABOT_LOGIN = 'dependabot[bot]';
+const CR_CONTEXT = 'coderabbit-review';
+
+export const HQ_COMMENT_TEMPLATE = `<!-- bot-hq -->
+## 🤖 Bot HQ
+
+<!-- bot-hq:issue-link -->
+### 🔗 Issue Link
+⚠️ No \`Closes #N\` found — add one to the PR description to auto-close on merge.
+<!-- /bot-hq:issue-link -->
+
+---
+
+<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> _Not yet requested_
+<!-- cr-section-end -->
+
+---
+<sub>This comment is managed by the bot — do not edit directly.</sub>`;
+
+const ALL_CR_LABELS = [
+  'coderabbit: not started',
+  'coderabbit: waiting',
+  'coderabbit: rate-limited',
+  'coderabbit: queued',
+  'coderabbit: unresolved',
+  'coderabbit: complete',
+];
+
+async function setExclusiveCRLabel(
+  github: GitHubClient,
+  prNumber: number,
+  newLabel: string,
+  currentLabels?: string[],
+): Promise<void> {
+  const labels = currentLabels ?? await github.getLabels(prNumber);
+  const toRemove = labels.filter(l => ALL_CR_LABELS.includes(l) && l !== newLabel);
+  await Promise.all(toRemove.map(l => github.removeLabel(prNumber, l).catch(() => {})));
+  if (!labels.includes(newLabel)) {
+    await github.addLabels(prNumber, [newLabel]);
+  }
+}
+
+function buildCRSectionNotStarted(currentBody?: string): string {
+  const checkboxes = getCheckedLabel(currentBody ?? '').replace(/\[x\]/g, '[ ]');
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+${checkboxes}
+
+> _Not yet requested_
+<!-- cr-section-end -->`;
+}
+
+function buildCRSectionWaiting(prNumber: number): string {
+  const now = new Date().toISOString();
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: ${now} -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> ⏳ Review requested for #${prNumber} — waiting for CodeRabbit response…
+<!-- cr-section-end -->`;
+}
+
+function buildCRSectionQueued(level: QueueLevel): string {
+  const levelLabel = level === 'priority' ? '🔴 Priority' : level === 'normal' ? '🟡 Normal' : '⬜ Backburner';
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> 📋 Queued as **${levelLabel}** — will trigger when a token is available.
+<!-- cr-section-end -->`;
+}
+
+function buildCRSectionComplete(): string {
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> ✅ Review complete — no blocking issues.
+<!-- cr-section-end -->`;
+}
+
+function buildCRSectionUnresolved(actionableCount: number): string {
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> ❌ Review complete — **${actionableCount} actionable comment(s)** require attention.
+<!-- cr-section-end -->`;
+}
+
+function replaceCRSection(hqBody: string, newSection: string): string {
+  return hqBody.replace(
+    /<!-- cr-section-start -->[\s\S]*?<!-- cr-section-end -->/,
+    newSection,
+  );
+}
+
+async function findHQComment(
+  github: GitHubClient,
+  prNumber: number,
+): Promise<{ id: number; body: string } | null> {
+  const comments = await github.getIssueComments(prNumber);
+  const hq = comments.find(c => c.user.login === BOT_LOGIN && c.body.includes('<!-- bot-hq -->'));
+  return hq ? { id: hq.id, body: hq.body } : null;
+}
+
+async function triggerOrEnqueue(
+  ctx: HandlerContext,
+  prNumber: number,
+  prTitle: string,
+  sha: string,
+  level: QueueLevel,
+): Promise<void> {
+  const { github, state, env } = ctx;
+  const queueState = await state.getState();
+
+  const hasTokens = queueState.tokens > 0;
+  const noPriorityInQueue = queueState.priority.length === 0;
+  const bucketFull = queueState.tokens === 3;
+
+  const shouldTriggerNow =
+    hasTokens && (
+      level === 'priority' ||
+      (level === 'normal' && noPriorityInQueue) ||
+      (level === 'backburner' && bucketFull)
+    );
+
+  if (shouldTriggerNow) {
+    // Post @coderabbitai review comment
+    await github.createComment(prNumber, '@coderabbitai full review');
+    await state.decrementToken();
+
+    // Swap label to waiting
+    await setExclusiveCRLabel(github, prNumber, 'coderabbit: waiting');
+    await github.setCommitStatus(sha, 'pending', CR_CONTEXT, 'CodeRabbit review in progress');
+
+    // Update HQ comment
+    const hq = await findHQComment(github, prNumber);
+    if (hq) {
+      const updatedBody = replaceCRSection(hq.body, buildCRSectionWaiting(prNumber));
+      await github.updateComment(hq.id, updatedBody);
+    }
+  } else {
+    // Enqueue
+    const newQueueState = enqueue(queueState, { pr: prNumber, title: prTitle, queued_at: new Date().toISOString() }, level);
+    await state.saveState(newQueueState);
+
+    await setExclusiveCRLabel(github, prNumber, 'coderabbit: queued');
+
+    // Update HQ comment
+    const hq = await findHQComment(github, prNumber);
+    if (hq) {
+      const updatedBody = replaceCRSection(hq.body, buildCRSectionQueued(level));
+      await github.updateComment(hq.id, updatedBody);
+    }
+
+    // Schedule coordinator if not already scheduled
+    if (!newQueueState.refill_qstash_id) {
+      const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
+      await scheduleCoordinator(env.QSTASH_TOKEN, 60, workerUrl);
+    }
+  }
+}
+
+export async function handlePullRequest(ctx: HandlerContext): Promise<void> {
+  const { github, payload } = ctx;
+  const action: string = payload.action;
+  const pr = payload.pull_request;
+  const prNumber: number = pr.number;
+  const sha: string = pr.head.sha;
+  const userLogin: string = pr.user.login;
+  const isDependabot = userLogin === DEPENDABOT_LOGIN;
+
+  if (action === 'opened') {
+    if (isDependabot) {
+      await github.setCommitStatus(sha, 'success', CR_CONTEXT, 'Dependabot PR — CR review not required');
+      return;
+    }
+
+    // Create HQ comment
+    await github.createComment(prNumber, HQ_COMMENT_TEMPLATE);
+    // Add label
+    await github.addLabels(prNumber, ['coderabbit: not started']);
+    // Set commit status
+    await github.setCommitStatus(sha, 'pending', CR_CONTEXT, 'CodeRabbit review not yet requested');
+    return;
+  }
+
+  if (action === 'synchronize') {
+    const labels = await github.getLabels(prNumber);
+    const isTerminal = labels.includes('coderabbit: complete') || labels.includes('coderabbit: unresolved');
+
+    if (isTerminal) {
+      // Remove all CR labels, add not started
+      await setExclusiveCRLabel(github, prNumber, 'coderabbit: not started', labels);
+      await github.setCommitStatus(sha, 'pending', CR_CONTEXT, 'CodeRabbit review not yet requested');
+
+      // Update HQ comment
+      const hq = await findHQComment(github, prNumber);
+      if (hq) {
+        const updatedBody = replaceCRSection(hq.body, buildCRSectionNotStarted(hq.body));
+        await github.updateComment(hq.id, updatedBody);
+      }
+    }
+  }
+}
+
+export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
+  const { github, state, env, payload } = ctx;
+  const action: string = payload.action;
+  const comment = payload.comment;
+  const issue = payload.issue;
+  const sender = payload.sender;
+
+  // Only handle PR comments
+  if (!issue.pull_request) return;
+
+  const prNumber: number = issue.number;
+  const commentBody: string = comment.body ?? '';
+  const commentAuthor: string = comment.user.login;
+  const senderLogin: string = sender.login;
+
+  if (commentAuthor === CR_BOT_LOGIN) {
+    if (isSkipComment(commentBody)) {
+      const pr = await github.getPR(prNumber);
+      await setExclusiveCRLabel(github, prNumber, 'coderabbit: complete');
+      await github.setCommitStatus(pr.head.sha, 'success', CR_CONTEXT, 'CodeRabbit review passed');
+
+      const hq = await findHQComment(github, prNumber);
+      if (hq) {
+        const updatedBody = replaceCRSection(hq.body, buildCRSectionComplete());
+        await github.updateComment(hq.id, updatedBody);
+      }
+      return;
+    }
+
+    if (isRateLimitComment(commentBody)) {
+      const pr = await github.getPR(prNumber);
+      await setExclusiveCRLabel(github, prNumber, 'coderabbit: rate-limited');
+      await github.setCommitStatus(pr.head.sha, 'pending', CR_CONTEXT, 'CodeRabbit rate-limited · retry scheduled');
+
+      // Compute delay and re-enqueue
+      const delaySecs = computeRateLimitDelay(commentBody, comment.created_at, Date.now());
+      const queueState = await state.getState();
+      const newQueueState = enqueue(
+        queueState,
+        { pr: prNumber, title: pr.title, queued_at: new Date().toISOString() },
+        'normal',
+      );
+      await state.saveState(newQueueState);
+
+      // Schedule coordinator
+      const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
+      await scheduleCoordinator(env.QSTASH_TOKEN, delaySecs, workerUrl);
+      return;
+    }
+
+    // Other CR bot comments: ignore
+    return;
+  }
+
+  // Human reviewer triggers: "@rickcedwhat-ai review" command
+  if (commentAuthor !== BOT_LOGIN && action === 'created' && /^@rickcedwhat-ai\s+(?:coderabbit\s+)?review/i.test(commentBody)) {
+    // Parse priority from command, default normal
+    let level: QueueLevel = 'normal';
+    if (/priority/i.test(commentBody)) level = 'priority';
+    else if (/backburner/i.test(commentBody)) level = 'backburner';
+
+    const pr = await github.getPR(prNumber);
+    await triggerOrEnqueue(ctx, prNumber, pr.title, pr.head.sha, level);
+    return;
+  }
+
+  // HQ comment checkbox edit detection
+  // The HQ comment is authored by BOT_LOGIN; an edit by someone else is a checkbox toggle
+  if (commentAuthor === BOT_LOGIN && senderLogin !== BOT_LOGIN && comment.body.includes('<!-- bot-hq -->')) {
+    const priority = getPriorityFromCheckbox(commentBody);
+    if (priority) {
+      const pr = await github.getPR(prNumber);
+      await triggerOrEnqueue(ctx, prNumber, pr.title, pr.head.sha, priority);
+    }
+  }
+}
+
+export async function handlePullRequestReview(ctx: HandlerContext): Promise<void> {
+  const { github, payload } = ctx;
+  const review = payload.review;
+  const pr = payload.pull_request;
+  const prNumber: number = pr.number;
+  const sha: string = pr.head.sha;
+  const reviewerLogin: string = review.user.login;
+  const reviewBody: string = review.body ?? '';
+  const reviewState: string = review.state ?? '';
+
+  if (reviewerLogin !== CR_BOT_LOGIN) return;
+
+  const actionableCount = parseActionableCount(reviewBody);
+  const isApproved = reviewState.toLowerCase() === 'approved';
+  const isChangesRequested = reviewState.toLowerCase() === 'changes_requested';
+  const hasBlocking = !isApproved && (isChangesRequested || actionableCount > 0);
+
+  if (hasBlocking) {
+    await setExclusiveCRLabel(github, prNumber, 'coderabbit: unresolved');
+    await github.setCommitStatus(sha, 'failure', CR_CONTEXT, 'CodeRabbit review has open comments');
+
+    const hq = await findHQComment(github, prNumber);
+    if (hq) {
+      const updatedBody = replaceCRSection(hq.body, buildCRSectionUnresolved(actionableCount));
+      await github.updateComment(hq.id, updatedBody);
+    }
+  } else {
+    await setExclusiveCRLabel(github, prNumber, 'coderabbit: complete');
+    await github.setCommitStatus(sha, 'success', CR_CONTEXT, 'CodeRabbit review passed');
+
+    const hq = await findHQComment(github, prNumber);
+    if (hq) {
+      const updatedBody = replaceCRSection(hq.body, buildCRSectionComplete());
+      await github.updateComment(hq.id, updatedBody);
+    }
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { Receiver } from '@upstash/qstash';
 import { GitHubClient } from './lib/github.js';
 import { StateManager } from './lib/state.js';
 import { handlePullRequest, handleIssueComment, handlePullRequestReview } from './handlers/webhook.js';
@@ -39,25 +40,15 @@ async function verifyQStashSignature(
   signatureHeader: string | null,
 ): Promise<boolean> {
   if (!signatureHeader) return false;
-
-  const encoder = new TextEncoder();
-
-  const verify = async (key: string): Promise<boolean> => {
-    const cryptoKey = await crypto.subtle.importKey(
-      'raw',
-      encoder.encode(key),
-      { name: 'HMAC', hash: 'SHA-256' },
-      false,
-      ['sign'],
-    );
-    const sig = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(body));
-    const expected = Array.from(new Uint8Array(sig))
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join('');
-    return signatureHeader === expected;
-  };
-
-  return (await verify(currentKey)) || (await verify(nextKey));
+  // Upstash-Signature is a JWT — use the official Receiver which validates
+  // the JWT signature, iss/sub/exp/nbf claims, and body hash correctly.
+  const receiver = new Receiver({ currentSigningKey: currentKey, nextSigningKey: nextKey });
+  try {
+    await receiver.verify({ signature: signatureHeader, body });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 const app = new Hono<{ Bindings: Env }>();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,138 @@
+import { Hono } from 'hono';
+import { GitHubClient } from './lib/github.js';
+import { StateManager } from './lib/state.js';
+import { handlePullRequest, handleIssueComment, handlePullRequestReview } from './handlers/webhook.js';
+import { handleCoordinator } from './handlers/coordinator.js';
+
+export interface Env {
+  BOT_PAT: string;
+  WEBHOOK_SECRET: string;
+  QSTASH_TOKEN: string;
+  QSTASH_CURRENT_SIGNING_KEY: string;
+  QSTASH_NEXT_SIGNING_KEY: string;
+  UPSTASH_REDIS_REST_URL: string;
+  UPSTASH_REDIS_REST_TOKEN: string;
+  GITHUB_REPO: string;
+  QUEUE_ISSUE_NUMBER: string;
+}
+
+async function verifyGitHubSignature(secret: string, body: string, signature: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+  const expected = 'sha256=' + Array.from(new Uint8Array(sig))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+  return signature === expected;
+}
+
+async function verifyQStashSignature(
+  currentKey: string,
+  nextKey: string,
+  body: string,
+  signatureHeader: string | null,
+): Promise<boolean> {
+  if (!signatureHeader) return false;
+
+  const encoder = new TextEncoder();
+
+  const verify = async (key: string): Promise<boolean> => {
+    const cryptoKey = await crypto.subtle.importKey(
+      'raw',
+      encoder.encode(key),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    const sig = await crypto.subtle.sign('HMAC', cryptoKey, encoder.encode(body));
+    const expected = Array.from(new Uint8Array(sig))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+    return signatureHeader === expected;
+  };
+
+  return (await verify(currentKey)) || (await verify(nextKey));
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get('/health', (c) => {
+  return c.json({ ok: true, version: '0.1.0' });
+});
+
+app.post('/webhook', async (c) => {
+  const body = await c.req.text();
+  const signature = c.req.header('X-Hub-Signature-256') ?? '';
+  const event = c.req.header('X-GitHub-Event') ?? '';
+
+  const valid = await verifyGitHubSignature(c.env.WEBHOOK_SECRET, body, signature);
+  if (!valid) {
+    return c.json({ error: 'Invalid signature' }, 401);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const github = new GitHubClient(c.env.BOT_PAT, c.env.GITHUB_REPO);
+  const state = new StateManager(c.env.UPSTASH_REDIS_REST_URL, c.env.UPSTASH_REDIS_REST_TOKEN);
+
+  const ctx = { github, state, env: c.env, event, payload };
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = payload as any;
+    const action: string = p.action ?? '';
+
+    if (event === 'pull_request' && (action === 'opened' || action === 'synchronize')) {
+      await handlePullRequest(ctx);
+    } else if (event === 'issue_comment' && (action === 'created' || action === 'edited')) {
+      await handleIssueComment(ctx);
+    } else if (event === 'pull_request_review' && action === 'submitted') {
+      await handlePullRequestReview(ctx);
+    }
+    // All others: 200 OK (ignored)
+
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error('Webhook handler error:', err);
+    return c.json({ error: 'Internal error' }, 500);
+  }
+});
+
+app.post('/coordinator', async (c) => {
+  const body = await c.req.text();
+  const signatureHeader = c.req.header('Upstash-Signature');
+
+  const valid = await verifyQStashSignature(
+    c.env.QSTASH_CURRENT_SIGNING_KEY,
+    c.env.QSTASH_NEXT_SIGNING_KEY,
+    body,
+    signatureHeader ?? null,
+  );
+  if (!valid) {
+    return c.json({ error: 'Invalid QStash signature' }, 401);
+  }
+
+  const github = new GitHubClient(c.env.BOT_PAT, c.env.GITHUB_REPO);
+  const state = new StateManager(c.env.UPSTASH_REDIS_REST_URL, c.env.UPSTASH_REDIS_REST_TOKEN);
+
+  try {
+    await handleCoordinator({ github, state, env: c.env });
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error('Coordinator error:', err);
+    return c.json({ error: 'Internal error' }, 500);
+  }
+});
+
+export default app;

--- a/worker/src/lib/coderabbit.ts
+++ b/worker/src/lib/coderabbit.ts
@@ -1,0 +1,122 @@
+import type { CommitState } from './types.js';
+
+/**
+ * Returns true if a pull_request_review body is a skip or rate-limit notice —
+ * not a real substantive review. These events must not trigger label transitions.
+ */
+export function isSkipOrRateLimitReview(body: string | null | undefined): boolean {
+  return /auto-generated comment: (?:rate limited|skip review) by coderabbit\.ai/i.test(body ?? '');
+}
+
+/**
+ * Returns true if the comment body contains the CR skip marker.
+ */
+export function isSkipComment(body: string | null | undefined): boolean {
+  return (body ?? '').includes('<!-- skip review by coderabbit.ai -->');
+}
+
+/**
+ * Returns true if the comment body contains rate-limit language from CodeRabbit.
+ */
+export function isRateLimitComment(body: string | null | undefined): boolean {
+  const b = body ?? '';
+  return /exceeded|try again in|available in \d+/i.test(b) ||
+         b.includes('rate limited by coderabbit.ai');
+}
+
+/**
+ * Parses the wait duration from a CodeRabbit rate-limit comment body.
+ * Looks for hours, minutes, and seconds independently.
+ * Returns milliseconds; falls back to 30 minutes if nothing matches.
+ */
+export function parseRateLimitDuration(body: string): number {
+  const hMatch = body.match(/(\d+)\s*hour/i);
+  const mMatch = body.match(/(\d+)\s*min/i);
+  const sMatch = body.match(/(\d+)\s*sec/i);
+  const ms = (hMatch ? parseInt(hMatch[1]) * 3_600_000 : 0)
+           + (mMatch ? parseInt(mMatch[1]) *    60_000 : 0)
+           + (sMatch ? parseInt(sMatch[1]) *     1_000 : 0);
+  return ms || 30 * 60_000;
+}
+
+/**
+ * Computes the QStash delay in seconds for a rate-limit retry.
+ * Anchors to when CR posted the rate-limit comment so elapsed processing
+ * time doesn't inflate the delay. Always adds a 60 s safety buffer.
+ */
+export function computeRateLimitDelay(
+  body: string,
+  createdAtIso: string | null,
+  nowMs: number,
+): number {
+  const durationMs = parseRateLimitDuration(body);
+  const commentedAt = createdAtIso ? new Date(createdAtIso).getTime() : NaN;
+  const anchor = isNaN(commentedAt) ? nowMs : commentedAt;
+  const availableAt = anchor + durationMs;
+  return Math.max(30, Math.ceil((availableAt - nowMs) / 1_000)) + 60;
+}
+
+/**
+ * Parses the number of actionable comments from a CodeRabbit review body.
+ */
+export function parseActionableCount(body: string | null | undefined): number {
+  const m = (body ?? '').match(/Actionable comments posted:\s*(\d+)/i);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Parses the number of nitpick comments from a CodeRabbit review body.
+ */
+export function parseNitpickCount(body: string | null | undefined): number {
+  const m = (body ?? '').match(/Nitpick comments\s*\((\d+)\)/i);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Returns the checkbox lines for the HQ CR section based on the current HQ body.
+ * Preserves whichever checkbox was previously selected; defaults to all unchecked.
+ */
+export function getCheckedLabel(hqBody: string | null | undefined): string {
+  const body = hqBody ?? '';
+  if (/- \[x\] 🔴/u.test(body))
+    return '- [x] 🔴 Priority review _(skips to front)_\n- [ ] 🟡 Normal review _(standard queue)_\n- [ ] ⬜ Backburner review _(triggers only when bucket is full)_';
+  if (/- \[x\] 🟡/u.test(body))
+    return '- [ ] 🔴 Priority review _(skips to front)_\n- [x] 🟡 Normal review _(standard queue)_\n- [ ] ⬜ Backburner review _(triggers only when bucket is full)_';
+  if (/- \[x\] ⬜/u.test(body))
+    return '- [ ] 🔴 Priority review _(skips to front)_\n- [ ] 🟡 Normal review _(standard queue)_\n- [x] ⬜ Backburner review _(triggers only when bucket is full)_';
+  // Old-style backward compat
+  if (/- \[x\] Full review/i.test(body))
+    return '- [x] Full review\n- [ ] Incremental review';
+  if (/- \[x\] Incremental review/i.test(body))
+    return '- [ ] Full review\n- [x] Incremental review';
+  return '- [ ] 🔴 Priority review _(skips to front)_\n- [ ] 🟡 Normal review _(standard queue)_\n- [ ] ⬜ Backburner review _(triggers only when bucket is full)_';
+}
+
+/**
+ * Extract priority level from HQ comment body checkbox state.
+ */
+export function getPriorityFromCheckbox(
+  hqBody: string | null | undefined,
+): 'priority' | 'normal' | 'backburner' | null {
+  const body = hqBody ?? '';
+  if (/- \[x\] 🔴/u.test(body)) return 'priority';
+  if (/- \[x\] 🟡/u.test(body)) return 'normal';
+  if (/- \[x\] ⬜/u.test(body)) return 'backburner';
+  if (/- \[x\] Full review/i.test(body)) return 'normal'; // backward compat
+  return null;
+}
+
+/**
+ * Maps the current label set to a commit status to post.
+ */
+export function labelToStatus(labelNames: string[]): { state: CommitState; description: string } {
+  if (labelNames.includes('coderabbit: complete'))
+    return { state: 'success', description: 'CodeRabbit review passed' };
+  if (labelNames.includes('coderabbit: unresolved'))
+    return { state: 'failure', description: 'CodeRabbit review has open comments' };
+  if (labelNames.includes('coderabbit: rate-limited'))
+    return { state: 'pending', description: 'CodeRabbit rate-limited · retry scheduled' };
+  if (labelNames.includes('coderabbit: waiting'))
+    return { state: 'pending', description: 'CodeRabbit review in progress' };
+  return { state: 'pending', description: 'CodeRabbit review not yet requested' };
+}

--- a/worker/src/lib/github.ts
+++ b/worker/src/lib/github.ts
@@ -57,7 +57,17 @@ export class GitHubClient {
     created_at: string;
     updated_at: string;
   }>> {
-    return this.request(`/repos/${this.repo}/issues/${issueNumber}/comments?per_page=100`);
+    const all: Array<{ id: number; user: { login: string }; body: string; created_at: string; updated_at: string }> = [];
+    let page = 1;
+    while (true) {
+      const batch: typeof all = await this.request(
+        `/repos/${this.repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+      );
+      all.push(...batch);
+      if (batch.length < 100) break;
+      page++;
+    }
+    return all;
   }
 
   async addLabels(issueNumber: number, labels: string[]): Promise<void> {

--- a/worker/src/lib/github.ts
+++ b/worker/src/lib/github.ts
@@ -1,0 +1,127 @@
+import type { CommitState } from './types.js';
+
+const BASE_URL = 'https://api.github.com';
+
+export class GitHubClient {
+  private headers: Record<string, string>;
+  private repo: string;
+
+  constructor(token: string, repo: string) {
+    this.repo = repo;
+    this.headers = {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'cr-bot/0.1.0',
+    };
+  }
+
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const url = `${BASE_URL}${path}`;
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        ...this.headers,
+        ...(options.headers as Record<string, string> ?? {}),
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`GitHub API error ${res.status} for ${path}: ${text}`);
+    }
+    // Some endpoints return 204 No Content
+    if (res.status === 204) return undefined as unknown as T;
+    return res.json() as Promise<T>;
+  }
+
+  async createComment(issueNumber: number, body: string): Promise<{ id: number }> {
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async updateComment(commentId: number, body: string): Promise<void> {
+    return this.request(`/repos/${this.repo}/issues/comments/${commentId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async getIssueComments(issueNumber: number): Promise<Array<{
+    id: number;
+    user: { login: string };
+    body: string;
+    created_at: string;
+    updated_at: string;
+  }>> {
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}/comments?per_page=100`);
+  }
+
+  async addLabels(issueNumber: number, labels: string[]): Promise<void> {
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}/labels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ labels }),
+    });
+  }
+
+  async removeLabel(issueNumber: number, label: string): Promise<void> {
+    const encoded = encodeURIComponent(label);
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}/labels/${encoded}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async getLabels(issueNumber: number): Promise<string[]> {
+    const labels = await this.request<Array<{ name: string }>>(
+      `/repos/${this.repo}/issues/${issueNumber}/labels`
+    );
+    return labels.map(l => l.name);
+  }
+
+  async setCommitStatus(
+    sha: string,
+    state: CommitState,
+    context: string,
+    description: string,
+  ): Promise<void> {
+    return this.request(`/repos/${this.repo}/statuses/${sha}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state, context, description }),
+    });
+  }
+
+  async getPR(prNumber: number): Promise<{
+    number: number;
+    title: string;
+    head: { sha: string };
+    base: { ref: string };
+    user: { login: string };
+  }> {
+    return this.request(`/repos/${this.repo}/pulls/${prNumber}`);
+  }
+
+  async updateIssue(issueNumber: number, body: string): Promise<void> {
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async getIssue(issueNumber: number): Promise<{ number: number; body: string }> {
+    return this.request(`/repos/${this.repo}/issues/${issueNumber}`);
+  }
+
+  async listOpenPRs(): Promise<Array<{ number: number; title: string; updated_at: string }>> {
+    return this.request(`/repos/${this.repo}/pulls?state=open&per_page=100`);
+  }
+
+  async getPRLabels(prNumber: number): Promise<string[]> {
+    return this.getLabels(prNumber);
+  }
+}

--- a/worker/src/lib/queue.ts
+++ b/worker/src/lib/queue.ts
@@ -1,0 +1,326 @@
+import type { QueueState, QueuedPR, QueueLevel } from './types.js';
+
+const DEFAULT_STATE: QueueState = {
+  tokens: 3,
+  last_decremented_at: '',
+  refill_qstash_id: '',
+  refill_at: '',
+  priority: [],
+  normal: [],
+  backburner: [],
+  reviews_this_session: 0,
+};
+
+/**
+ * Parses the <!-- cr-queue-state ... --> block from the Queue Issue body.
+ * Returns safe default state if block is missing or malformed.
+ */
+export function parseQueueState(issueBody: string | null | undefined): QueueState {
+  const body = issueBody ?? '';
+  const m = body.match(/<!-- cr-queue-state\n([\s\S]*?)\n-->/);
+  if (!m) return { ...DEFAULT_STATE };
+
+  const block = m[1];
+  try {
+    const get = (key: string): string | null => {
+      const line = block.match(new RegExp(`^${key}:\\s*(.*)$`, 'm'));
+      if (!line) return null;
+      const val = line[1].trim();
+      // '-' is the empty placeholder used by serializeQueueState
+      return val === '-' ? '' : val;
+    };
+
+    const tokensRaw = get('tokens');
+    const tokens = tokensRaw !== null ? parseInt(tokensRaw, 10) : 3;
+
+    const parseArr = (key: string): QueuedPR[] => {
+      const raw = get(key);
+      if (!raw) return [];
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    };
+
+    const reviewsRaw = get('reviews_this_session');
+    const reviews_this_session = reviewsRaw !== null ? parseInt(reviewsRaw, 10) : 0;
+
+    return {
+      tokens: isNaN(tokens) ? 3 : Math.min(3, Math.max(0, tokens)),
+      last_decremented_at: get('last_decremented_at') ?? '',
+      refill_qstash_id: get('refill_qstash_id') ?? '',
+      refill_at: (() => {
+        const v = get('refill_at') ?? '';
+        try { if (v) new Date(v).toISOString(); return v; } catch { return ''; }
+      })(),
+      priority: parseArr('priority'),
+      normal: parseArr('normal'),
+      backburner: parseArr('backburner'),
+      reviews_this_session: isNaN(reviews_this_session) ? 0 : Math.max(0, reviews_this_session),
+    };
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+/**
+ * Regenerates the full Queue Issue body with machine-readable state block
+ * AND human-readable markdown tables.
+ */
+export function serializeQueueState(
+  state: QueueState,
+  { inReview = 0, unresolved = 0 }: { inReview?: number; unresolved?: number } = {},
+  liveItems: Array<{ pr: number; title: string; status: string; updated: string }> = [],
+): string {
+  const nowMs = Date.now();
+
+  const pad = (v: string | number | null | undefined): string =>
+    (v === '' || v == null || v === '-' || (typeof v === 'string' && v.trim() === '')) ? '-' : String(v);
+
+  const stateBlock = [
+    '<!-- cr-queue-state',
+    `tokens: ${state.tokens}`,
+    `last_decremented_at: ${pad(state.last_decremented_at)}`,
+    `refill_qstash_id: ${pad(state.refill_qstash_id)}`,
+    `refill_at: ${pad(state.refill_at)}`,
+    `priority: ${JSON.stringify(state.priority)}`,
+    `normal: ${JSON.stringify(state.normal)}`,
+    `backburner: ${JSON.stringify(state.backburner)}`,
+    `reviews_this_session: ${state.reviews_this_session || 0}`,
+    '-->',
+  ].join('\n');
+
+  let nextRefillStr = '';
+  if (state.refill_at) {
+    try {
+      const refillMs = new Date(state.refill_at).getTime();
+      const diffMs = refillMs - nowMs;
+      if (diffMs > 0) {
+        const refillHHMM = new Date(refillMs).toISOString().slice(11, 16);
+        nextRefillStr = `· Next refill: ~${refillHHMM} UTC`;
+      }
+    } catch { /* ignore */ }
+  }
+  const qstashStr = state.refill_qstash_id
+    ? `· QStash: \`${state.refill_qstash_id}\``
+    : '';
+  const bucketLine = `🪣 **Token bucket: ${state.tokens} / 3** ${nextRefillStr} ${qstashStr}`.trim();
+
+  const queuedCount = state.priority.length + state.normal.length + state.backburner.length;
+  const statsLine = `📊 ${queuedCount} queued · ${inReview} in review · ${unresolved} unresolved · ${state.reviews_this_session || 0} reviews this session`;
+
+  const safeTitle = (t: string | undefined): string => String(t ?? '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|');
+
+  const LEVEL_ICON: Record<QueueLevel, string> = {
+    priority: '🔴 Priority',
+    normal: '🟡 Normal',
+    backburner: '⬜ Backburner',
+  };
+
+  const buildQueueTable = (): string => {
+    const lines = ['### 📋 Review Queue'];
+    lines.push('| Level | PR | Title | Queued |');
+    lines.push('|---|---|---|---|');
+    const allQueued = [
+      ...state.priority.map(item => ({ ...item, level: 'priority' as QueueLevel })),
+      ...state.normal.map(item => ({ ...item, level: 'normal' as QueueLevel })),
+      ...state.backburner.map(item => ({ ...item, level: 'backburner' as QueueLevel })),
+    ];
+    if (allQueued.length === 0) {
+      lines.push('| — | _empty_ | — | — |');
+    } else {
+      for (const item of allQueued) {
+        lines.push(`| ${LEVEL_ICON[item.level]} | #${item.pr} | ${safeTitle(item.title)} | ${formatRelativeTime(item.queued_at, nowMs)} |`);
+      }
+    }
+    return lines.join('\n');
+  };
+
+  const STATUS_ICON: Record<string, string> = {
+    'coderabbit: waiting':     '⏳ Waiting',
+    'coderabbit: unresolved':  '❌ Unresolved',
+    'coderabbit: complete':    '✅ Complete',
+    'coderabbit: not started': '🔲 Not started',
+  };
+
+  const STATUS_ORDER: Record<string, number> = {
+    'coderabbit: waiting':     0,
+    'coderabbit: unresolved':  1,
+    'coderabbit: complete':    2,
+    'coderabbit: not started': 3,
+  };
+
+  const THREE_DAYS_MS = 3 * 86_400_000;
+
+  const buildLiveTable = (items: typeof liveItems): string | null => {
+    if (!items || items.length === 0) return null;
+    const sorted = [...items].sort((a, b) => {
+      const ao = STATUS_ORDER[a.status] ?? 99;
+      const bo = STATUS_ORDER[b.status] ?? 99;
+      return ao - bo;
+    });
+    const lines = ['### 🔍 Active PRs'];
+    lines.push('| Status | PR | Title | Updated |');
+    lines.push('|---|---|---|---|');
+    for (const item of sorted) {
+      let icon = STATUS_ICON[item.status] ?? item.status;
+      if (item.status === 'coderabbit: unresolved' && item.updated) {
+        const updMs = new Date(item.updated).getTime();
+        if (!isNaN(updMs) && (nowMs - updMs) > THREE_DAYS_MS) {
+          icon = `⚠️ Unresolved`;
+        }
+      }
+      lines.push(`| ${icon} | #${item.pr} | ${safeTitle(item.title)} | ${formatRelativeTime(item.updated, nowMs)} |`);
+    }
+    return lines.join('\n');
+  };
+
+  const liveTable = buildLiveTable(liveItems);
+
+  const parts = [
+    stateBlock,
+    '',
+    '## 🐰 CodeRabbit Review Queue',
+    bucketLine,
+    statsLine,
+    '',
+    buildQueueTable(),
+  ];
+
+  if (liveTable) {
+    parts.push('', liveTable);
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Lazy bucket refill: min(3, stored_tokens + floor((nowMs - lastDecrMs) / 3600000))
+ * Returns updated state with recalculated tokens. Does NOT mutate input.
+ */
+export function computeActualTokens(
+  state: Pick<QueueState, 'tokens' | 'last_decremented_at'> & Partial<QueueState>,
+  nowMs: number,
+): QueueState {
+  if (!state.last_decremented_at) return { ...DEFAULT_STATE, ...state } as QueueState;
+  const lastDecrMs = new Date(state.last_decremented_at).getTime();
+  if (isNaN(lastDecrMs)) return { ...DEFAULT_STATE, ...state } as QueueState;
+  const hoursElapsed = Math.max(0, Math.floor((nowMs - lastDecrMs) / 3_600_000));
+  const actualTokens = Math.min(3, state.tokens + hoursElapsed);
+  return { ...DEFAULT_STATE, ...state, tokens: actualTokens } as QueueState;
+}
+
+/**
+ * Priority selection:
+ *   1. First item in priority[]
+ *   2. First item in normal[]
+ *   3. First item in backburner[] — ONLY if state.tokens === 3
+ *   4. null (nothing to trigger)
+ */
+export function pickNextPR(
+  state: QueueState,
+): (QueuedPR & { level: QueueLevel }) | null {
+  if (state.priority.length > 0)
+    return { ...state.priority[0], level: 'priority' };
+  if (state.normal.length > 0)
+    return { ...state.normal[0], level: 'normal' };
+  if (state.backburner.length > 0 && state.tokens === 3)
+    return { ...state.backburner[0], level: 'backburner' };
+  return null;
+}
+
+/**
+ * Add a PR to the appropriate queue.
+ * priority → unshift (front); normal/backburner → push (back)
+ * Idempotent: does not add if PR is already in ANY queue.
+ */
+export function enqueue(
+  state: QueueState,
+  prInfo: QueuedPR,
+  level: QueueLevel,
+): QueueState {
+  const inAny = [...state.priority, ...state.normal, ...state.backburner]
+    .some(item => item.pr === prInfo.pr);
+  if (inAny) return { ...state };
+
+  const newState: QueueState = {
+    ...state,
+    priority: [...state.priority],
+    normal: [...state.normal],
+    backburner: [...state.backburner],
+  };
+
+  if (level === 'priority') {
+    newState.priority.unshift(prInfo);
+  } else if (level === 'normal') {
+    newState.normal.push(prInfo);
+  } else {
+    newState.backburner.push(prInfo);
+  }
+
+  return newState;
+}
+
+/**
+ * Remove a PR from all queues by pr number. Returns updated state.
+ */
+export function dequeue(state: QueueState, prNumber: number): QueueState {
+  return {
+    ...state,
+    priority: state.priority.filter(item => item.pr !== prNumber),
+    normal: state.normal.filter(item => item.pr !== prNumber),
+    backburner: state.backburner.filter(item => item.pr !== prNumber),
+  };
+}
+
+/**
+ * Returns position info for a PR in the queues, or null if not found.
+ */
+export function findPRInQueues(
+  state: QueueState,
+  prNumber: number,
+): { level: QueueLevel; position: number; total: number } | null {
+  const queues: Array<{ level: QueueLevel; items: QueuedPR[] }> = [
+    { level: 'priority', items: state.priority },
+    { level: 'normal', items: state.normal },
+    { level: 'backburner', items: state.backburner },
+  ];
+  for (const { level, items } of queues) {
+    const idx = items.findIndex(item => item.pr === prNumber);
+    if (idx !== -1) {
+      return { level, position: idx + 1, total: items.length };
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns human-readable relative time.
+ */
+export function formatRelativeTime(isoString: string, nowMs: number): string {
+  if (!isoString) return '';
+  const ms = new Date(isoString).getTime();
+  if (isNaN(ms)) return '';
+  const diffMs = nowMs - ms;
+  if (diffMs < 60_000) return 'just now';
+  const diffMins = Math.floor(diffMs / 60_000);
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffMs / 86_400_000);
+  return `${diffDays}d ago`;
+}
+
+/**
+ * Increments reviews_this_session by 1. Does NOT mutate input.
+ */
+export function incrementReviewsThisSession(
+  state: Pick<QueueState, 'reviews_this_session'> & Partial<QueueState>,
+): QueueState {
+  return { ...DEFAULT_STATE, ...state, reviews_this_session: (state.reviews_this_session || 0) + 1 } as QueueState;
+}

--- a/worker/src/lib/state.ts
+++ b/worker/src/lib/state.ts
@@ -90,9 +90,13 @@ export class StateManager {
   }
 
   async decrementToken(): Promise<number> {
-    const newVal = await this.redis.decr(KEYS.tokens);
-    await this.redis.set(KEYS.lastDecremented, new Date().toISOString());
-    return newVal;
+    // Pipeline both ops so decr and timestamp update succeed or fail together
+    const now = new Date().toISOString();
+    const pipeline = this.redis.pipeline();
+    pipeline.decr(KEYS.tokens);
+    pipeline.set(KEYS.lastDecremented, now);
+    const results = await pipeline.exec();
+    return (results[0] as number) ?? 0;
   }
 
   async incrementToken(): Promise<number> {

--- a/worker/src/lib/state.ts
+++ b/worker/src/lib/state.ts
@@ -1,0 +1,107 @@
+import { Redis } from '@upstash/redis/cloudflare';
+import type { QueueState, QueuedPR } from './types.js';
+
+const KEYS = {
+  tokens: 'cr:tokens',
+  lastDecremented: 'cr:last_decremented',
+  refillQstashId: 'cr:refill_qstash_id',
+  refillAt: 'cr:refill_at',
+  queuePriority: 'cr:queue:priority',
+  queueNormal: 'cr:queue:normal',
+  queueBackburner: 'cr:queue:backburner',
+  reviewsSession: 'cr:reviews_session',
+} as const;
+
+const MAX_TOKENS = 3;
+
+export class StateManager {
+  private redis: Redis;
+
+  constructor(url: string, token: string) {
+    this.redis = new Redis({ url, token });
+  }
+
+  async getState(): Promise<QueueState> {
+    const [
+      tokensRaw,
+      lastDecrRaw,
+      refillQstashId,
+      refillAt,
+      priorityRaw,
+      normalRaw,
+      backburnerRaw,
+      reviewsRaw,
+    ] = await Promise.all([
+      this.redis.get<number>(KEYS.tokens),
+      this.redis.get<string>(KEYS.lastDecremented),
+      this.redis.get<string>(KEYS.refillQstashId),
+      this.redis.get<string>(KEYS.refillAt),
+      this.redis.get<string>(KEYS.queuePriority),
+      this.redis.get<string>(KEYS.queueNormal),
+      this.redis.get<string>(KEYS.queueBackburner),
+      this.redis.get<number>(KEYS.reviewsSession),
+    ]);
+
+    const storedTokens = tokensRaw ?? MAX_TOKENS;
+    const lastDecrMs = lastDecrRaw ? new Date(lastDecrRaw).getTime() : NaN;
+    const nowMs = Date.now();
+
+    // Lazy refill: add 1 token per elapsed hour since last decrement
+    let tokens = storedTokens;
+    if (!isNaN(lastDecrMs)) {
+      const hoursElapsed = Math.max(0, Math.floor((nowMs - lastDecrMs) / 3_600_000));
+      tokens = Math.min(MAX_TOKENS, storedTokens + hoursElapsed);
+    }
+    tokens = Math.max(0, Math.min(MAX_TOKENS, tokens));
+
+    const parseQueue = (raw: string | null): QueuedPR[] => {
+      if (!raw) return [];
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    };
+
+    return {
+      tokens,
+      last_decremented_at: lastDecrRaw ?? '',
+      refill_qstash_id: refillQstashId ?? '',
+      refill_at: refillAt ?? '',
+      priority: parseQueue(priorityRaw),
+      normal: parseQueue(normalRaw),
+      backburner: parseQueue(backburnerRaw),
+      reviews_this_session: reviewsRaw ?? 0,
+    };
+  }
+
+  async saveState(state: QueueState): Promise<void> {
+    const pipeline = this.redis.pipeline();
+    pipeline.set(KEYS.tokens, state.tokens);
+    pipeline.set(KEYS.lastDecremented, state.last_decremented_at || '');
+    pipeline.set(KEYS.refillQstashId, state.refill_qstash_id || '');
+    pipeline.set(KEYS.refillAt, state.refill_at || '');
+    pipeline.set(KEYS.queuePriority, JSON.stringify(state.priority));
+    pipeline.set(KEYS.queueNormal, JSON.stringify(state.normal));
+    pipeline.set(KEYS.queueBackburner, JSON.stringify(state.backburner));
+    pipeline.set(KEYS.reviewsSession, state.reviews_this_session);
+    await pipeline.exec();
+  }
+
+  async decrementToken(): Promise<number> {
+    const newVal = await this.redis.decr(KEYS.tokens);
+    await this.redis.set(KEYS.lastDecremented, new Date().toISOString());
+    return newVal;
+  }
+
+  async incrementToken(): Promise<number> {
+    const newVal = await this.redis.incr(KEYS.tokens);
+    // Cap at MAX_TOKENS
+    if (newVal > MAX_TOKENS) {
+      await this.redis.set(KEYS.tokens, MAX_TOKENS);
+      return MAX_TOKENS;
+    }
+    return newVal;
+  }
+}

--- a/worker/src/lib/types.ts
+++ b/worker/src/lib/types.ts
@@ -1,0 +1,28 @@
+export interface QueuedPR {
+  pr: number;
+  title: string;
+  queued_at: string;
+}
+
+export type QueueLevel = 'priority' | 'normal' | 'backburner';
+
+export interface QueueState {
+  tokens: number;
+  last_decremented_at: string;
+  refill_qstash_id: string;
+  refill_at: string;
+  priority: QueuedPR[];
+  normal: QueuedPR[];
+  backburner: QueuedPR[];
+  reviews_this_session: number;
+}
+
+export type CRLabel =
+  | 'coderabbit: not started'
+  | 'coderabbit: waiting'
+  | 'coderabbit: rate-limited'
+  | 'coderabbit: queued'
+  | 'coderabbit: unresolved'
+  | 'coderabbit: complete';
+
+export type CommitState = 'pending' | 'success' | 'failure' | 'error';

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,22 @@
+name = "cr-bot"
+main = "src/index.ts"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+account_id = "d9827daf3c416e4c825e1af18e5e408a"
+
+[vars]
+GITHUB_REPO = "rickcedwhat/playwright-smart-table"
+QUEUE_ISSUE_NUMBER = "262"
+
+# Secrets (set via: wrangler secret put SECRET_NAME)
+# BOT_PAT
+# WEBHOOK_SECRET
+# QSTASH_TOKEN
+# QSTASH_CURRENT_SIGNING_KEY
+# QSTASH_NEXT_SIGNING_KEY
+# UPSTASH_REDIS_REST_URL
+# UPSTASH_REDIS_REST_TOKEN
+
+[env.staging]
+name = "cr-bot-staging"
+vars = { GITHUB_REPO = "rickcedwhat/playwright-smart-table", QUEUE_ISSUE_NUMBER = "262" }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,6 @@
 name = "cr-bot"
 main = "src/index.ts"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-06-11"
 compatibility_flags = ["nodejs_compat"]
 account_id = "d9827daf3c416e4c825e1af18e5e408a"
 


### PR DESCRIPTION
## What

Replaces the fragmented GHA bot workflows with a single Cloudflare Worker that handles all CodeRabbit review automation logic in ~1400 lines of TypeScript.

**Live at:** `https://cr-bot.ccata002.workers.dev`

## Confirmed working (tested live)

- `pull_request.synchronize` → resets `complete`/`unresolved` → `not started`
- `issue_comment` with `@rickcedwhat-ai review` → posts `@coderabbitai full review`, sets `waiting`
- `pull_request_review` APPROVED → sets `coderabbit: complete`

## Structure

```
worker/
├── wrangler.toml          # CF config, account ID, env vars
├── tsconfig.json
├── package.json           # hono, @upstash/redis, @upstash/qstash
└── src/
    ├── index.ts           # Hono app — /webhook, /coordinator, /health
    ├── handlers/
    │   ├── webhook.ts     # PR / comment / review event handlers
    │   └── coordinator.ts # QStash coordinator (token bucket queue)
    └── lib/
        ├── github.ts      # GitHub API client
        ├── state.ts       # Upstash Redis state manager
        ├── coderabbit.ts  # CR detection logic
        ├── queue.ts       # Queue state functions
        └── types.ts       # TypeScript interfaces
```

## Still to do (follow-up PRs)

- [ ] HQ comment creation on `pull_request.opened`
- [ ] Rate-limit detection (CR edits its summary comment)
- [ ] Queue dashboard — write to Queue Issue #262
- [ ] `@rickcedwhat-ai promote #N` command
- [ ] Dependabot passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated PR review queue system with priority-based scheduling
  * Added real-time queue status tracking via GitHub comment dashboard
  * Integrated rate-limit detection and automatic re-queuing capabilities
  * Enhanced GitHub webhook integration for seamless review workflow automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->