### PR TITLE
feat(worker): promote command, rate-limit HQ update, reminder command

### DIFF
--- a/worker/src/handlers/coordinator.ts
+++ b/worker/src/handlers/coordinator.ts
@@ -164,7 +164,7 @@ export async function handleCoordinator(ctx: CoordinatorContext): Promise<void> 
   await updateQueueIssueDashboard(github, env, queueState);
 }
 
-async function updateQueueIssueDashboard(
+export async function updateQueueIssueDashboard(
   github: GitHubClient,
   env: Env,
   queueState: QueueState,

--- a/worker/src/handlers/webhook.ts
+++ b/worker/src/handlers/webhook.ts
@@ -11,8 +11,8 @@ import {
   getPriorityFromCheckbox,
   labelToStatus,
 } from '../lib/coderabbit.js';
-import { enqueue, dequeue, pickNextPR } from '../lib/queue.js';
-import { scheduleCoordinator } from './coordinator.js';
+import { enqueue, dequeue, pickNextPR, findPRInQueues } from '../lib/queue.js';
+import { scheduleCoordinator, updateQueueIssueDashboard } from './coordinator.js';
 
 export interface HandlerContext {
   github: GitHubClient;
@@ -138,6 +138,19 @@ function buildCRSectionUnresolved(actionableCount: number): string {
 - [ ] ⬜ Backburner review _(triggers only when bucket is full)_
 
 > ❌ Review complete — **${actionableCount} actionable comment(s)** require attention.
+<!-- cr-section-end -->`;
+}
+
+function buildCRSectionRateLimited(retryAt: string): string {
+  return `<!-- cr-section-start -->
+<!-- cr-trigger-time: -->
+
+### 🔍 CodeRabbit Review
+- [ ] 🔴 Priority review _(skips to front)_
+- [ ] 🟡 Normal review _(standard queue)_
+- [ ] ⬜ Backburner review _(triggers only when bucket is full)_
+
+> ⏱ Rate-limited · retry scheduled · fires ~${retryAt} UTC
 <!-- cr-section-end -->`;
 }
 
@@ -318,9 +331,24 @@ export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
       );
       await state.saveState(newQueueState);
 
-      // Schedule coordinator
+      // Schedule coordinator and persist the messageId + refill_at
       const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
-      await scheduleCoordinator(env.QSTASH_TOKEN, delaySecs, workerUrl);
+      const msgId = await scheduleCoordinator(env.QSTASH_TOKEN, delaySecs, workerUrl);
+      if (msgId) {
+        const updatedState = {
+          ...newQueueState,
+          refill_qstash_id: msgId,
+          refill_at: new Date(Date.now() + delaySecs * 1000).toISOString(),
+        };
+        await state.saveState(updatedState);
+      }
+
+      // Update HQ comment to show rate-limited status with retry time
+      const hq = await findHQComment(github, prNumber);
+      if (hq) {
+        const retryAt = new Date(Date.now() + delaySecs * 1000).toISOString().slice(11, 16);
+        await github.updateComment(hq.id, replaceCRSection(hq.body, buildCRSectionRateLimited(retryAt)));
+      }
       return;
     }
 
@@ -338,6 +366,68 @@ export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
     const pr = await github.getPR(prNumber);
     await triggerOrEnqueue(ctx, prNumber, pr.title, pr.head.sha, level);
     return;
+  }
+
+  // @rickcedwhat-ai promote #N command
+  if (commentAuthor !== BOT_LOGIN && action === 'created') {
+    const promoteMatch = commentBody.match(/^@rickcedwhat-ai\s+promote\s+#(\d+)/i);
+    if (promoteMatch) {
+      const targetPR = parseInt(promoteMatch[1], 10);
+      const queueState = await state.getState();
+      const found = findPRInQueues(queueState, targetPR);
+
+      if (!found) {
+        await github.createComment(prNumber, `❌ PR #${targetPR} is not in the queue.`);
+      } else if (found.level === 'priority') {
+        await github.createComment(prNumber, `PR #${targetPR} is already in the 🔴 Priority queue.`);
+      } else {
+        // Dequeue then re-enqueue at priority
+        const pr = await github.getPR(targetPR);
+        const afterDequeue = dequeue(queueState, targetPR);
+        const afterEnqueue = enqueue(
+          afterDequeue,
+          { pr: targetPR, title: pr.title, queued_at: new Date().toISOString() },
+          'priority',
+        );
+        await state.saveState(afterEnqueue);
+        await github.createComment(prNumber, `✅ PR #${targetPR} promoted to 🔴 Priority queue.`);
+
+        // Update Queue Issue dashboard
+        await updateQueueIssueDashboard(github, env, afterEnqueue);
+      }
+      return;
+    }
+  }
+
+  // @rickcedwhat-ai reminder <delay> command
+  if (commentAuthor !== BOT_LOGIN && action === 'created') {
+    const reminderMatch = commentBody.match(/^@rickcedwhat-ai\s+reminder\s+(\d+)([mhd])/i);
+    if (reminderMatch) {
+      const amount = parseInt(reminderMatch[1], 10);
+      const unit = reminderMatch[2].toLowerCase();
+      const multiplier: Record<string, number> = { m: 60, h: 3600, d: 86400 };
+      const delaySecs = amount * (multiplier[unit] ?? 60);
+
+      const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
+      const reminderUrl = `https://qstash.upstash.io/v2/publish/${workerUrl}/reminder`;
+      try {
+        await fetch(reminderUrl, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${env.QSTASH_TOKEN}`,
+            'Content-Type': 'application/json',
+            'Upstash-Delay': `${delaySecs}s`,
+          },
+          body: JSON.stringify({ pr_number: prNumber, repo: env.GITHUB_REPO }),
+        });
+      } catch (err) {
+        console.error('Failed to schedule reminder:', err);
+      }
+
+      const unitLabel = unit === 'm' ? `${amount}m` : unit === 'h' ? `${amount}h` : `${amount}d`;
+      await github.createComment(prNumber, `⏱ Reminder scheduled for ${unitLabel}.`);
+      return;
+    }
   }
 
   // HQ comment checkbox edit detection

--- a/worker/src/handlers/webhook.ts
+++ b/worker/src/handlers/webhook.ts
@@ -331,23 +331,23 @@ export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
       );
       await state.saveState(newQueueState);
 
-      // Schedule coordinator and persist the messageId + refill_at
+      // Schedule coordinator — only update HQ if scheduling actually succeeded
       const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
       const msgId = await scheduleCoordinator(env.QSTASH_TOKEN, delaySecs, workerUrl);
       if (msgId) {
+        const retryAt = new Date(Date.now() + delaySecs * 1000).toISOString().slice(11, 16);
         const updatedState = {
           ...newQueueState,
           refill_qstash_id: msgId,
           refill_at: new Date(Date.now() + delaySecs * 1000).toISOString(),
         };
         await state.saveState(updatedState);
-      }
 
-      // Update HQ comment to show rate-limited status with retry time
-      const hq = await findHQComment(github, prNumber);
-      if (hq) {
-        const retryAt = new Date(Date.now() + delaySecs * 1000).toISOString().slice(11, 16);
-        await github.updateComment(hq.id, replaceCRSection(hq.body, buildCRSectionRateLimited(retryAt)));
+        // Update HQ to show retry time only when retry is actually scheduled
+        const hq = await findHQComment(github, prNumber);
+        if (hq) {
+          await github.updateComment(hq.id, replaceCRSection(hq.body, buildCRSectionRateLimited(retryAt)));
+        }
       }
       return;
     }
@@ -411,7 +411,7 @@ export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
       const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
       const reminderUrl = `https://qstash.upstash.io/v2/publish/${workerUrl}/reminder`;
       try {
-        await fetch(reminderUrl, {
+        const res = await fetch(reminderUrl, {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${env.QSTASH_TOKEN}`,
@@ -420,12 +420,16 @@ export async function handleIssueComment(ctx: HandlerContext): Promise<void> {
           },
           body: JSON.stringify({ pr_number: prNumber, repo: env.GITHUB_REPO }),
         });
+        if (!res.ok) {
+          console.error(`Failed to schedule reminder: QStash returned ${res.status}`);
+          return;
+        }
+        // Only confirm to the user when scheduling actually succeeded
+        const unitLabel = unit === 'm' ? `${amount}m` : unit === 'h' ? `${amount}h` : `${amount}d`;
+        await github.createComment(prNumber, `⏱ Reminder scheduled for ${unitLabel}.`);
       } catch (err) {
         console.error('Failed to schedule reminder:', err);
       }
-
-      const unitLabel = unit === 'm' ? `${amount}m` : unit === 'h' ? `${amount}h` : `${amount}d`;
-      await github.createComment(prNumber, `⏱ Reminder scheduled for ${unitLabel}.`);
       return;
     }
   }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -126,4 +126,40 @@ app.post('/coordinator', async (c) => {
   }
 });
 
+app.post('/reminder', async (c) => {
+  const body = await c.req.text();
+  const signatureHeader = c.req.header('Upstash-Signature');
+
+  const valid = await verifyQStashSignature(
+    c.env.QSTASH_CURRENT_SIGNING_KEY,
+    c.env.QSTASH_NEXT_SIGNING_KEY,
+    body,
+    signatureHeader ?? null,
+  );
+  if (!valid) {
+    return c.json({ error: 'Invalid QStash signature' }, 401);
+  }
+
+  let payload: { pr_number?: number; repo?: string };
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return c.json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const prNumber = payload.pr_number;
+  if (!prNumber) {
+    return c.json({ error: 'Missing pr_number' }, 400);
+  }
+
+  const github = new GitHubClient(c.env.BOT_PAT, c.env.GITHUB_REPO);
+  try {
+    await github.createComment(prNumber, '👋 Reminder: this PR is still open.');
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error('Reminder handler error:', err);
+    return c.json({ error: 'Internal error' }, 500);
+  }
+});
+
 export default app;


### PR DESCRIPTION
## What

Three missing features added to the CR bot Worker.

**`@rickcedwhat-ai promote #N`**
Moves a PR from normal/backburner to the front of the priority queue. Replies with confirmation or an error if the PR isn't queued. Updates the Queue Issue dashboard.

**Rate-limit HQ update**
When CR rate-limits a triggered review, the HQ comment now shows the retry time (`⏱ Rate-limited · retry scheduled · fires ~HH:MM UTC`). The QStash messageId and `refill_at` are also persisted to Redis so other processes see the scheduled job.

**`@rickcedwhat-ai reminder Xm/h/d`**
Schedules a reminder comment via QStash. Supports `m` (minutes), `h` (hours), `d` (days). Posts confirmation immediately, fires `👋 Reminder: this PR is still open.` after the delay via a new `/reminder` Worker route.

**Export `updateQueueIssueDashboard`** from coordinator so the promote handler can reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New `promote` command allows prioritizing pull requests in the queue
  * New `reminder` command enables scheduling reminders with custom delays  
  * Rate-limit responses now include retry timestamp information for better user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->