### PR TITLE
fix(worker): bucketFull MAX_TOKENS + dashboard updates on every enqueue/trigger

### DIFF
--- a/worker/src/handlers/webhook.ts
+++ b/worker/src/handlers/webhook.ts
@@ -11,7 +11,7 @@ import {
   getPriorityFromCheckbox,
   labelToStatus,
 } from '../lib/coderabbit.js';
-import { enqueue, dequeue, pickNextPR, findPRInQueues } from '../lib/queue.js';
+import { enqueue, dequeue, pickNextPR, findPRInQueues, MAX_TOKENS } from '../lib/queue.js';
 import { scheduleCoordinator, updateQueueIssueDashboard } from './coordinator.js';
 
 export interface HandlerContext {
@@ -182,7 +182,7 @@ async function triggerOrEnqueue(
 
   const hasTokens = queueState.tokens > 0;
   const noPriorityInQueue = queueState.priority.length === 0;
-  const bucketFull = queueState.tokens === 3;
+  const bucketFull = queueState.tokens === MAX_TOKENS;
 
   const shouldTriggerNow =
     hasTokens && (
@@ -206,6 +206,8 @@ async function triggerOrEnqueue(
       const updatedBody = replaceCRSection(hq.body, buildCRSectionWaiting(prNumber));
       await github.updateComment(hq.id, updatedBody);
     }
+
+    await updateQueueIssueDashboard(github, env, await state.getState());
   } else {
     // Enqueue
     const newQueueState = enqueue(queueState, { pr: prNumber, title: prTitle, queued_at: new Date().toISOString() }, level);
@@ -221,18 +223,21 @@ async function triggerOrEnqueue(
     }
 
     // Schedule coordinator if not already scheduled, and persist the messageId
+    let finalState = newQueueState;
     if (!newQueueState.refill_qstash_id) {
       const workerUrl = `https://cr-bot.${env.GITHUB_REPO.split('/')[0]}.workers.dev`;
       const msgId = await scheduleCoordinator(env.QSTASH_TOKEN, 60, workerUrl);
       if (msgId) {
-        const withSchedule = {
+        finalState = {
           ...newQueueState,
           refill_qstash_id: msgId,
           refill_at: new Date(Date.now() + 60_000).toISOString(),
         };
-        await state.saveState(withSchedule);
+        await state.saveState(finalState);
       }
     }
+
+    await updateQueueIssueDashboard(github, env, finalState);
   }
 }
 

--- a/worker/src/lib/queue.ts
+++ b/worker/src/lib/queue.ts
@@ -33,7 +33,7 @@ export function parseQueueState(issueBody: string | null | undefined): QueueStat
     };
 
     const tokensRaw = get('tokens');
-    const tokens = tokensRaw !== null ? parseInt(tokensRaw, 10) : 3;
+    const tokens = tokensRaw !== null ? parseInt(tokensRaw, 10) : MAX_TOKENS;
 
     const parseArr = (key: string): QueuedPR[] => {
       const raw = get(key);
@@ -108,7 +108,7 @@ export function serializeQueueState(
   const qstashStr = state.refill_qstash_id
     ? `· QStash: \`${state.refill_qstash_id}\``
     : '';
-  const bucketLine = `🪣 **Token bucket: ${state.tokens} / 3** ${nextRefillStr} ${qstashStr}`.trim();
+  const bucketLine = `🪣 **Token bucket: ${state.tokens} / ${MAX_TOKENS}** ${nextRefillStr} ${qstashStr}`.trim();
 
   const queuedCount = state.priority.length + state.normal.length + state.backburner.length;
   const statsLine = `📊 ${queuedCount} queued · ${inReview} in review · ${unresolved} unresolved · ${state.reviews_this_session || 0} reviews this session`;
@@ -221,7 +221,7 @@ export function computeActualTokens(
  * Priority selection:
  *   1. First item in priority[]
  *   2. First item in normal[]
- *   3. First item in backburner[] — ONLY if state.tokens === 3
+ *   3. First item in backburner[] — ONLY if state.tokens === MAX_TOKENS
  *   4. null (nothing to trigger)
  */
 export function pickNextPR(


### PR DESCRIPTION
## Summary

- **`bucketFull` bug**: `webhook.ts` compared `queueState.tokens === 3` — always `false` with `MAX_TOKENS=1`, so backburner PRs were never triggered directly. Fixed to `=== MAX_TOKENS`.
- **Dashboard staleness**: `updateQueueIssueDashboard` was only called from the coordinator and `@bot promote`. Added it to both branches of `triggerOrEnqueue` (trigger path and enqueue path), so issue #262 updates on every webhook event.
- **Remaining `3` literals in `queue.ts`**: `parseQueueState` fallback, `bucketLine` display string (`/ 3` → `/ ${MAX_TOKENS}`), and `pickNextPR` docstring.

## Test plan

- [ ] `pnpm test` in `worker/` passes (108 tests)
- [ ] Deploy to Cloudflare via `deploy-worker` CI once merged
- [ ] Trigger a review on any PR and verify issue #262 body updates immediately
- [ ] Enqueue a PR (trigger while rate-limited) and verify issue #262 shows it in the queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved token bucket initialization to use consistent configuration values across queue operations.
  * Fixed queue state persistence to ensure the dashboard properly reflects current queue status after state changes.

* **Refactor**
  * Optimized state management logic for improved reliability and maintainability in queue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->