### PR TITLE
fix(ci): upload metrics as artifact instead of pushing to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,11 +93,9 @@ jobs:
         if: steps.check_version.outputs.changed == 'true' && success()
         run: node scripts/collect-metrics.mjs
 
-      - name: Commit Metrics
+      - name: Upload Metrics Artifact
         if: steps.check_version.outputs.changed == 'true' && success()
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add metrics/history.json
-          git diff --cached --quiet || git commit -m "chore: record metrics for v${{ steps.check_version.outputs.version }} [skip ci]"
-          git push
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-v${{ steps.check_version.outputs.version }}
+          path: metrics/history.json


### PR DESCRIPTION
## Summary

- The publish workflow's "Commit Metrics" step pushes directly to `main`, which fails branch protection (requires PR + signed commits + status checks)
- Replaces the push with `actions/upload-artifact` — metrics are still captured and available in the Actions run for the standard retention period

## Test plan

- [ ] Merge and confirm next publish run completes without the `remote rejected` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)