### PR TITLE
feat(pagination): expose detectCurrentPage in Strategies.Pagination.click()

### DIFF
--- a/src/strategies/pagination.ts
+++ b/src/strategies/pagination.ts
@@ -32,6 +32,7 @@ export const PaginationStrategies = {  /**
     nextBulkPages?: number,
     previousBulkPages?: number,
     numberOfPages?: number | ((root: import('@playwright/test').Locator) => number | Promise<number>),
+    detectCurrentPage?: (root: import('@playwright/test').Locator) => number | Promise<number>,
     stabilization?: StabilizationStrategy,
     timeout?: number
   } = {}): PaginationStrategy => {
@@ -87,6 +88,7 @@ export const PaginationStrategies = {  /**
       } : undefined,
       nextBulkPages: nextBulk,
       previousBulkPages: prevBulk,
+      detectCurrentPage: options.detectCurrentPage,
     };
   },
 

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -19,5 +19,6 @@
         "!src/types.ts",
         "!src/typeContext.ts",
         "!src/minimalConfigContext.ts"
-    ]
+    ],
+    "disableTypeChecks": "src/**/*.ts"
 }


### PR DESCRIPTION
## Summary

- **Closes #212**: Adds `detectCurrentPage` as an optional option to `Strategies.Pagination.click()`. Previously the only way to use this hook was to hand-write a raw strategy object — now it's a first-class option on the convenience builder, closing the last gap between `PaginationPrimitives` and `click()`.
- **Closes #204**: Scopes Stryker's `disableTypeChecks` to `src/**/*.ts`. Without this, Stryker's preprocessor tried to parse `coverage/lcov-report/*.ts.html` files and threw a parse error on every weekly mutation run.

## Changes

`src/strategies/pagination.ts` — 3 lines: add `detectCurrentPage` to the `options` type and pass it through to the returned strategy object.

`stryker.config.json` — 1 line: `"disableTypeChecks": "src/**/*.ts"`.

## Usage

```typescript
Strategies.Pagination.click(
  { next: '[aria-label="Next page"]' },
  {
    detectCurrentPage: async (root) => {
      const text = await root.locator('[aria-current="page"]').textContent();
      return parseInt(text ?? '1') - 1;
    }
  }
)
```

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `pnpm run test:unit` passes
- [ ] Weekly mutation run no longer errors on `.html` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)