### PR TITLE
chore: update AGENTS.md + CLAUDE.md — remove worktree/CodeRabbit refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,20 +6,9 @@ This file is the shared source of truth for all AI agents working on this repo.
 
 ## Agent Workflow
 
-Two agents operate on this project with different isolation strategies:
+Both Claude Code and Antigravity work on branches within the main worktree.
 
-| Agent | Isolation | Why |
-|---|---|---|
-| **Claude Code** | Git worktrees | Async tasks — works in a separate directory so the main checkout stays clean |
-| **Antigravity** | Branches within the main worktree | Workspace-bound tools; stays in the current working directory |
-
-### Claude Code
-
-Claude creates a new worktree for each task and opens a PR when done. You never need to switch branches or stash work — Claude's directory is separate from yours.
-
-### Antigravity
-
-Antigravity operates inside the main worktree. Use the `antigravity` branch as a sandbox for exploratory work, then create a descriptive feature branch for the PR (e.g. `feat/issue-42-row-virtualization`). Do **not** switch to or modify a worktree directory — those belong to Claude.
+Use a descriptive feature branch for each task (e.g. `feat/issue-42-row-virtualization`). Open a PR when done — the bot will post a Bot HQ comment automatically. Trigger an AI review by checking a checkbox in that comment or commenting `@rickcedwhat-ai review`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,7 @@ See `AGENTS.md` for shared conventions (package manager, branch strategy, releas
 
 ## Claude-Specific Setup
 
-**Isolation**: Claude uses git worktrees. Each task gets its own working directory — never modify the main checkout or switch branches manually.
-
-**Package manager**: pnpm. Run `pnpm install --frozen-lockfile` after checking out a worktree.
+**Package manager**: pnpm. Run `pnpm install --frozen-lockfile` before building or testing.
 
 ---
 
@@ -100,7 +98,7 @@ Running `pnpm run build` executes all generators then compiles TypeScript.
    ```bash
    git fetch origin && git rebase origin/main
    ```
-2. Only open PRs as drafts for genuine WIP. CodeRabbit auto-review is disabled — trigger reviews manually with `@rickcedwhat-ai coderabbit review` when ready.
+2. Only open PRs as drafts for genuine WIP. To trigger an AI review, check a checkbox in the Bot HQ comment or comment `@rickcedwhat-ai review`.
 
 ## PR Checklist
 


### PR DESCRIPTION
- Removes worktree isolation instructions from both files (no longer used)
- Updates bot trigger docs: `@rickcedwhat-ai review` replaces `@coderabbitai review`
- Simplifies agent workflow section in AGENTS.md