### PR TITLE
ci: add pnpm audit step to catch high/critical CVEs on PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Check Commit Messages (commitlint)
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+      - name: Audit Dependencies
+        run: pnpm audit --audit-level=high
+
   test-a:
     name: Unit + Core Tests (playground)
     needs: changes


### PR DESCRIPTION
Adds `pnpm audit --audit-level=high` to the `lint` job so any high/critical CVEs in dependencies block merge. Catches vulnerabilities that surface during the 7-day dependabot soak window.