### PR TITLE
chore: configure issue template chooser for Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question / get help
+    url: https://github.com/rickcedwhat/playwright-smart-table/discussions/new?category=q-a
+    about: Questions, usage help, and "how do I?" — use Discussions so others can find the answer


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/config.yml` to control the new-issue chooser screen
- Disables blank issues — forces use of a template, reduces noise
- Adds a Discussions link so Q&A questions go there instead of becoming freeform issues

## Dependencies

Discussions is already enabled with Q&A, Ideas, and Announcements categories.

Closes #134

## Test plan

- [ ] Click "New Issue" in the repo — verify blank issue option is gone
- [ ] Verify "Ask a question / get help" link appears and points to Discussions Q&A

🤖 Generated with [Claude Code](https://claude.com/claude-code)