### PR TITLE
chore(deps): override fast-uri to >=3.1.2 to clear high CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,10 @@
     "vitepress-plugin-tabs": "^0.9.0",
     "vitest": "^3.2.6"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "overrides": {
+      "fast-uri": ">=3.1.2"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: '>=3.1.2'
+
 importers:
 
   .:
@@ -1710,9 +1713,6 @@ packages:
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
-
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
@@ -3900,7 +3900,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4230,8 +4230,6 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-
-  fast-uri@3.1.0: {}
 
   fast-uri@3.1.2: {}
 


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` to force `fast-uri >= 3.1.2` across the dependency tree
- Stryker pins `ajv ~8.18.0` which was resolving `fast-uri@3.1.0` — vulnerable to two high CVEs (GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc)
- `pnpm audit --prod --audit-level=high` now passes clean

## Why override instead of upgrading stryker?

Stryker 9.6.1 is the latest version and the `ajv ~8.18.0` dep is a patch-only range — there's no newer stryker release to upgrade to. The override is the correct tool here and only affects dev dependencies.

Closes #300

## Test plan

- [ ] CI `lint` job passes (audit step)
- [ ] `pnpm why fast-uri` shows a single version `3.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)