### PR TITLE
feat(presets): add rdg2D preset for 2D-virtualized react-data-grid

### DIFF
--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,4 +1,4 @@
 export { muiTable, muiDataGrid } from './mui';
-export { RDG as rdg } from './rdg';
+export { RDG as rdg, RDG2D as rdg2D } from './rdg';
 export { Glide as glide, createGlide, createGlideViewport } from './glide';
 export type { GlideOptions, GlideViewportOptions } from './glide';

--- a/src/presets/rdg.ts
+++ b/src/presets/rdg.ts
@@ -1,4 +1,4 @@
-import { TableContext, Selector, TableConfig } from '../types';
+import { TableContext, Selector, TableConfig, ViewportStrategy } from '../types';
 import { PaginationStrategies } from '../strategies/pagination';
 import { StabilizationStrategies } from '../strategies/stabilization';
 
@@ -136,3 +136,92 @@ export const RDG: Partial<TableConfig> & { Strategies: typeof RDGStrategies } = 
     'Strategies',
     { get: () => RDGStrategies, enumerable: false }
 ) as Partial<TableConfig> & { Strategies: typeof RDGStrategies };
+
+// ---------------------------------------------------------------------------
+// rdg2D — React Data Grid with both rows AND columns virtualized
+// ---------------------------------------------------------------------------
+
+const rdg2DViewportStrategy: ViewportStrategy = {
+    getVisibleRowRange: async ({ root }) => {
+        return root.evaluate((el) => {
+            const rows = [...el.querySelectorAll('[role="row"][aria-rowindex]')];
+            const indices = rows.map(r => parseInt(r.getAttribute('aria-rowindex') || '0', 10) - 1);
+            if (!indices.length) return { first: 0, last: 0 };
+            return { first: Math.min(...indices), last: Math.max(...indices) };
+        });
+    },
+
+    getVisibleColumnRange: async ({ root }) => {
+        return root.evaluate((el) => {
+            const cells = [...el.querySelectorAll('[role="gridcell"][aria-colindex]')];
+            const indices = cells.map(c => parseInt(c.getAttribute('aria-colindex') || '0', 10) - 1);
+            if (!indices.length) return { first: 0, last: 0 };
+            return { first: Math.min(...indices), last: Math.max(...indices) };
+        });
+    },
+
+    scrollToRow: async ({ root }, rowIndex) => {
+        await root.evaluate((el, rowIndex) => {
+            const grid = (el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el) as HTMLElement;
+
+            // Try to locate the target row by aria-rowindex (1-based in RDG)
+            const ariaIndex = rowIndex + 1;
+            const targetRow = el.querySelector(`[role="row"][aria-rowindex="${ariaIndex}"]`) as HTMLElement | null;
+            if (targetRow) {
+                const top = parseInt(targetRow.style.top || '0', 10);
+                grid.scrollTop = Math.max(0, top - grid.clientHeight / 3);
+                return;
+            }
+
+            // Row not in DOM — estimate position from an actual visible row's height
+            const anyRow = el.querySelector('[role="row"][aria-rowindex]') as HTMLElement | null;
+            const rowHeight = anyRow ? anyRow.getBoundingClientRect().height || 35 : 35;
+            grid.scrollTop = Math.max(0, rowIndex * rowHeight - grid.clientHeight / 3);
+        }, rowIndex);
+    },
+
+    scrollToColumn: async ({ root }, columnIndex) => {
+        await root.evaluate((el, columnIndex) => {
+            const grid = (el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el) as HTMLElement;
+
+            // Try to locate the header cell by aria-colindex (1-based in RDG)
+            const ariaIndex = columnIndex + 1;
+            const header = el.querySelector(`[role="columnheader"][aria-colindex="${ariaIndex}"]`) as HTMLElement | null;
+            if (header) {
+                grid.scrollLeft = header.offsetLeft;
+                return;
+            }
+
+            // Column not visible — estimate from average width of visible headers
+            const headers = [...el.querySelectorAll('[role="columnheader"][aria-colindex]')] as HTMLElement[];
+            if (headers.length > 0) {
+                const avgWidth = headers.reduce((sum, h) => sum + h.offsetWidth, 0) / headers.length;
+                grid.scrollLeft = Math.max(0, columnIndex * avgWidth);
+            }
+        }, columnIndex);
+    },
+};
+
+/** Default strategies for the RDG2D preset (extends RDG with viewport recovery). */
+const RDG2DDefaultStrategies = {
+    ...RDGDefaultStrategies,
+    viewport: rdg2DViewportStrategy,
+};
+
+// fallow-ignore-next-line unused-export
+export const RDG2DStrategies = RDG2DDefaultStrategies;
+
+/**
+ * Full preset for React Data Grid with 2D virtualization (rows + columns both virtualized).
+ * Use instead of `rdg` when horizontal scrolling causes "could not reach cell" errors.
+ * The viewport strategy detects when a row is evicted by a horizontal scroll and restores it.
+ */
+const RDG2DPreset: Partial<TableConfig> = {
+    ...RDGPreset,
+    strategies: RDG2DDefaultStrategies,
+};
+export const RDG2D: Partial<TableConfig> & { Strategies: typeof RDG2DStrategies } = Object.defineProperty(
+    RDG2DPreset,
+    'Strategies',
+    { get: () => RDG2DStrategies, enumerable: false }
+) as Partial<TableConfig> & { Strategies: typeof RDG2DStrategies };

--- a/tests/integration/rdg-2d.spec.ts
+++ b/tests/integration/rdg-2d.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+import { useTable, presets } from '../../src/index';
+
+const RDG_URL = 'https://comcast.github.io/react-data-grid/#/CommonFeatures';
+
+test.describe('React Data Grid 2D (rdg2D preset)', () => {
+    test.setTimeout(90000);
+
+    test('collects all headers including those beyond the initial viewport', async ({ page }) => {
+        await page.goto(RDG_URL, { waitUntil: 'domcontentloaded' });
+
+        const grid = page.locator('[role="grid"]').first();
+        await expect(grid).toBeAttached({ timeout: 10000 });
+
+        const table = useTable(grid, { ...presets.rdg2D });
+        await table.init();
+
+        const headers = await table.getHeaders();
+        expect(headers.length).toBeGreaterThanOrEqual(15);
+        expect(headers).toContain('ID');
+        expect(headers).toContain('Task');
+    });
+
+    test('reads all columns for a row without "could not reach cell" errors', async ({ page }) => {
+        await page.goto(RDG_URL, { waitUntil: 'domcontentloaded' });
+
+        const grid = page.locator('[role="grid"]').first();
+        await expect(grid).toBeAttached({ timeout: 10000 });
+
+        const table = useTable(grid, { ...presets.rdg2D });
+        await table.init();
+
+        const rows = await table.findRows({}, { maxPages: 1 });
+        expect(rows.length).toBeGreaterThan(0);
+
+        const rowData = await rows[0].toJSON();
+        expect(Object.keys(rowData).length).toBeGreaterThanOrEqual(15);
+        expect(rowData).toHaveProperty('ID');
+        expect(rowData).toHaveProperty('Task');
+    });
+
+    test('map collects unique rows across pages without stale-locator errors', async ({ page }) => {
+        await page.goto(RDG_URL, { waitUntil: 'domcontentloaded' });
+
+        const grid = page.locator('[role="grid"]').first();
+        await expect(grid).toBeAttached({ timeout: 10000 });
+
+        const table = useTable(grid, {
+            ...presets.rdg2D,
+            strategies: {
+                ...presets.rdg2D.strategies,
+                dedupe: async (row) => row.getCell('ID').innerText(),
+            },
+        });
+
+        await table.init();
+
+        const rows = await table.map(
+            ({ row }) => row.toJSON({ columns: ['ID', 'Task'] }),
+            { maxPages: 4 },
+        );
+
+        const dataRows = rows.filter((r: any) => r.ID !== 'Total');
+        expect(dataRows.length).toBeGreaterThanOrEqual(50);
+
+        // All IDs must be valid positive integers
+        expect(dataRows.every((r: any) => /^\d+$/.test(String(r.ID)))).toBe(true);
+
+        // No duplicates
+        const uniqueIds = new Set(dataRows.map((r: any) => r.ID));
+        expect(uniqueIds.size).toBe(dataRows.length);
+    });
+
+    test('getCell works for columns at different horizontal positions', async ({ page }) => {
+        await page.goto(RDG_URL, { waitUntil: 'domcontentloaded' });
+
+        const grid = page.locator('[role="grid"]').first();
+        await expect(grid).toBeAttached({ timeout: 10000 });
+
+        const table = useTable(grid, { ...presets.rdg2D });
+        await table.init();
+
+        const rows = await table.findRows({}, { maxPages: 1 });
+        const firstRow = rows[0];
+
+        const data = await firstRow.toJSON({ columns: ['ID', 'Task', 'Completion'] });
+        expect(data).toHaveProperty('ID');
+        expect(data).toHaveProperty('Task');
+        expect(data).toHaveProperty('Completion');
+    });
+});

--- a/tests/integration/rdg-2d.spec.ts
+++ b/tests/integration/rdg-2d.spec.ts
@@ -55,19 +55,21 @@ test.describe('React Data Grid 2D (rdg2D preset)', () => {
 
         await table.init();
 
+        type RdgRow = { ID: string; Task?: string };
+
         const rows = await table.map(
             ({ row }) => row.toJSON({ columns: ['ID', 'Task'] }),
             { maxPages: 4 },
-        );
+        ) as RdgRow[];
 
-        const dataRows = rows.filter((r: any) => r.ID !== 'Total');
+        const dataRows = rows.filter(r => r.ID !== 'Total');
         expect(dataRows.length).toBeGreaterThanOrEqual(50);
 
         // All IDs must be valid positive integers
-        expect(dataRows.every((r: any) => /^\d+$/.test(String(r.ID)))).toBe(true);
+        expect(dataRows.every(r => /^\d+$/.test(String(r.ID)))).toBe(true);
 
         // No duplicates
-        const uniqueIds = new Set(dataRows.map((r: any) => r.ID));
+        const uniqueIds = new Set(dataRows.map(r => r.ID));
         expect(uniqueIds.size).toBe(dataRows.length);
     });
 
@@ -81,9 +83,9 @@ test.describe('React Data Grid 2D (rdg2D preset)', () => {
         await table.init();
 
         const rows = await table.findRows({}, { maxPages: 1 });
-        const firstRow = rows[0];
+        expect(rows.length).toBeGreaterThan(0);
 
-        const data = await firstRow.toJSON({ columns: ['ID', 'Task', 'Completion'] });
+        const data = await rows[0].toJSON({ columns: ['ID', 'Task', 'Completion'] });
         expect(data).toHaveProperty('ID');
         expect(data).toHaveProperty('Task');
         expect(data).toHaveProperty('Completion');


### PR DESCRIPTION
Closes #306

## Summary

- Adds `presets.rdg2D` — a drop-in replacement for `presets.rdg` for react-data-grid tables where both rows **and** columns are virtualized simultaneously
- Implements a custom `ViewportStrategy` with four RDG-specific methods that prevent "could not reach cell" errors caused by horizontal scrolling evicting rows from the DOM
- Exports `RDG2DStrategies` for callers who want strategies only (same pattern as `RDGStrategies`)

## Viewport strategy details

| Method | Behaviour |
|---|---|
| `getVisibleRowRange` | Queries `[role="row"][aria-rowindex]`, converts 1-based RDG indices to 0-based |
| `getVisibleColumnRange` | Queries `[role="gridcell"][aria-colindex]`, converts 1-based to 0-based |
| `scrollToRow` | Reads `style.top` when the row is in DOM; falls back to **measuring height of a visible row** (not hardcoded 35px) when the row has been evicted |
| `scrollToColumn` | Jumps via `aria-colindex` header `offsetLeft`; falls back to average visible column width |

## Test plan

- [ ] New `tests/integration/rdg-2d.spec.ts` — 4 tests against `comcast.github.io/react-data-grid`:
  - Headers collected (≥15 including virtualized columns)
  - `toJSON()` reads all columns without errors
  - `map()` collects 50+ unique rows across pages with no stale-locator errors
  - `getCell` works across different horizontal column positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the new `rdg2D` preset, enabling 2D virtualization for efficient handling of large data grids with optimized row and column scrolling capabilities.

* **Tests**
  * Added integration tests to verify 2D virtualization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->