### PR TITLE
fix(stryker): move vitest-runner to top-level plugins

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,10 +1,8 @@
 {
     "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
-    "mutator": {
-        "plugins": [
-            "@stryker-mutator/vitest-runner"
-        ]
-    },
+    "plugins": [
+        "@stryker-mutator/vitest-runner"
+    ],
     "packageManager": "pnpm",
     "reporters": [
         "html",


### PR DESCRIPTION
## Summary

- `mutator.plugins` is for AST mutator plugins (Babel transforms etc.) — Stryker's plugin loader never looks there for test runner plugins
- Moving `@stryker-mutator/vitest-runner` to the top-level `plugins` array makes Stryker find and load it correctly
- Verified locally: dry run reaches `INFO DryRunExecutor` and runs all 175 unit tests before mutation begins

## Root cause

The CI log showed: `Cannot find TestRunner plugin "vitest". In fact, no TestRunner plugins were loaded.` — the plugin was installed but declared under the wrong key.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified mutation testing tool configuration structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->