### PR TITLE
docs: fix write columnOverride signature

### DIFF
--- a/docs/guide/describe/column-overrides.md
+++ b/docs/guide/describe/column-overrides.md
@@ -27,9 +27,9 @@ If a column uses a custom editor that `smartFill` can't auto-detect, define how 
 useTable(locator, {
   columnOverrides: {
     StartDate: {
-      write: async (cell, value) => {
+      write: async ({ cell, targetValue }) => {
         await cell.click()
-        await page.getByRole('dialog').getByLabel('Date').fill(value)
+        await page.getByRole('dialog').getByLabel('Date').fill(targetValue)
         await page.getByRole('button', { name: 'Confirm' }).click()
       },
     },


### PR DESCRIPTION
## Summary

The `write` callback in `docs/guide/describe/column-overrides.md` was shown with two positional args `(cell, value)` but the actual type expects a single params object:

```typescript
write?: (params: { cell, targetValue, currentValue, row }) => Promise<void>
```

Updated the example to use the correct destructured form.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example code in the guides to reflect the current callback signature and demonstrate proper usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->