### PR TITLE
fix: add rdg and glide sub-path entries to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,14 @@
     "./presets/mui": {
       "types": "./dist/presets/mui.d.ts",
       "default": "./dist/presets/mui.js"
+    },
+    "./presets/rdg": {
+      "types": "./dist/presets/rdg.d.ts",
+      "default": "./dist/presets/rdg.js"
+    },
+    "./presets/glide": {
+      "types": "./dist/presets/glide/index.d.ts",
+      "default": "./dist/presets/glide/index.js"
     }
   },
   "keywords": [

--- a/src/presets/glide/index.ts
+++ b/src/presets/glide/index.ts
@@ -152,3 +152,5 @@ export const Glide: Partial<TableConfig> & { Strategies: typeof GlideStrategies 
     'Strategies',
     { get: () => GlideStrategies, enumerable: false }
 ) as Partial<TableConfig> & { Strategies: typeof GlideStrategies };
+
+export { Glide as glide };

--- a/src/presets/rdg.ts
+++ b/src/presets/rdg.ts
@@ -225,3 +225,5 @@ export const RDG2D: Partial<TableConfig> & { Strategies: typeof RDG2DStrategies 
     'Strategies',
     { get: () => RDG2DStrategies, enumerable: false }
 ) as Partial<TableConfig> & { Strategies: typeof RDG2DStrategies };
+
+export { RDG as rdg, RDG2D as rdg2D };


### PR DESCRIPTION
## Summary

- Adds `./presets/rdg` and `./presets/glide` to the `exports` map using the same `{ types, default }` shape as the existing `./presets/mui` entry
- Adds lowercase `rdg`/`rdg2D` aliases in `src/presets/rdg.ts` for consistency with the barrel export
- Adds lowercase `glide` alias in `src/presets/glide/index.ts`

Fixes strict-mode Node/bundler resolution failure for direct sub-path imports:
```ts
import { rdg } from 'playwright-smart-table/presets/rdg'   // previously: module-not-found
import { glide } from 'playwright-smart-table/presets/glide'
```

## Test plan
- [x] `pnpm run build` passes
- [x] `dist/presets/rdg.js`, `dist/presets/rdg.d.ts`, `dist/presets/glide/index.js`, `dist/presets/glide/index.d.ts` all present after build

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)