### PR TITLE
chore: remove dead _hasPaginated variable and fix generateConfig wording

### DIFF
--- a/src/useTable.ts
+++ b/src/useTable.ts
@@ -112,9 +112,6 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
     return item;
   };
 
-  // Internal State
-  let _hasPaginated = false;
-
   // Helpers
   const log = (msg: string) => {
     logDebug(config, 'verbose', msg);
@@ -353,7 +350,6 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
         log("No goToFirst strategy configured. Table may not be on page 1.");
       }
 
-      _hasPaginated = false;
       tableState.currentPageIndex = 0;
       tableMapper.clear();
       log("Table reset complete. Calling autoInit to restore state.");
@@ -555,7 +551,11 @@ export const useTable = <T = any>(rootLocator: Locator, configOptions: TableConf
       log("Generating table config prompt...");
       const html = await _getCleanHtml(rootLocator);
       const separator = "=".repeat(50);
-      const content = `\n${separator} \n🤖 COPY INTO GEMINI / ChatGPT 🤖\n${separator} \nI am using 'playwright-smart-table'.\nTarget Table Locator: ${rootLocator.toString()} \nGenerate config for: \n\`\`\`html\n${html.substring(0, 10000)} ...\n\`\`\`\n${separator}\n`;
+      const maxLen = 10000;
+      const truncated = html.length > maxLen;
+      const htmlSnippet = truncated ? html.substring(0, maxLen) : html;
+      const truncationNote = truncated ? `\n[truncated — ${html.length} chars total, showing first ${maxLen}]` : '';
+      const content = `\n${separator} \n🤖 Paste into your AI assistant 🤖\n${separator} \nI am using 'playwright-smart-table'.\nTarget Table Locator: ${rootLocator.toString()} \nGenerate config for: \n\`\`\`html\n${htmlSnippet}${truncationNote}\n\`\`\`\n${separator}\n`;
       await _handlePrompt('Smart Table Config', content);
     },
 

--- a/tests/generateConfig.spec.ts
+++ b/tests/generateConfig.spec.ts
@@ -16,7 +16,7 @@ test.describe('generateConfig', () => {
 
         const table = useTable(page.locator('#my-table'));
 
-        await expect(table.generateConfig()).rejects.toThrow(/COPY INTO GEMINI/);
+        await expect(table.generateConfig()).rejects.toThrow(/Paste into your AI assistant/);
 
         try {
             await table.generateConfig();
@@ -26,7 +26,7 @@ test.describe('generateConfig', () => {
             expect(message).toContain('Val 2');
             expect(message).toContain(tableHTML.trim());
             expect(message).toContain(MINIMAL_CONFIG_CONTEXT);
-            expect(message).toContain('COPY INTO GEMINI / ChatGPT');
+            expect(message).toContain('Paste into your AI assistant');
         }
     });
 
@@ -36,7 +36,7 @@ test.describe('generateConfig', () => {
         `);
         const table = useTable(page.locator('#t'));
 
-        await expect(table.generateConfigPrompt()).rejects.toThrow(/COPY INTO GEMINI/);
+        await expect(table.generateConfigPrompt()).rejects.toThrow(/Paste into your AI assistant/);
         // Implementation also calls console.warn with deprecation message
     });
 });


### PR DESCRIPTION
## Summary

Two small `useTable.ts` cleanups:

**#320 — dead `_hasPaginated` variable**
- `let _hasPaginated = false` was declared, reset in `reset()`, but never read or set to `true` — a vestige of a removed feature. Deleted.

**#325 — `generateConfig` vendor string**
- Replaced `"🤖 COPY INTO GEMINI / ChatGPT 🤖"` with `"🤖 Paste into your AI assistant 🤖"`
- Replaced bare `...` truncation with a proper note: `[truncated — {n} chars total, showing first 10000]`

Closes #320
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)