### PR TITLE
chore: CI hygiene — fix pnpm-lock.yaml path in codeql, bump bot-listener to Node 24

### DIFF
--- a/.github/workflows/bot-listener.yml
+++ b/.github/workflows/bot-listener.yml
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Run upstream watch
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
@@ -116,7 +116,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Fetch this issue as array
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
       - 'tests/**'
       - 'playground/**'
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
       - 'tsconfig*.json'
       - 'scripts/**'
       - 'vite.config*.ts'


### PR DESCRIPTION
## Summary

Fixes #319.

- `codeql-analysis.yml`: replace `package-lock.json` path trigger with `pnpm-lock.yaml` (this project uses pnpm; the old path never existed)
- `bot-listener.yml`: bump both `setup-node` steps from Node 20 → Node 24, matching every other workflow in the repo

## Test plan

- [ ] No build changes — CI workflow config only
- [ ] Verify `codeql-analysis.yml` triggers on `pnpm-lock.yaml` changes
- [ ] Verify `bot-listener.yml` runs on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)