### PR TITLE
fix: remove hardcoded 500ms sort delay from MUI preset; fix sentinel rowIndex

### DIFF
--- a/src/engine/rowFinder.ts
+++ b/src/engine/rowFinder.ts
@@ -46,7 +46,7 @@ export class RowFinder<T = any> {
 
         const sentinel = this.resolve(this.config.rowSelector, this.rootLocator)
             .filter({ hasText: "___SENTINEL_ROW_NOT_FOUND___" + Date.now() });
-        const smartRow = this.makeSmartRow(sentinel, await this.tableMapper.getMap(), 0);
+        const smartRow = this.makeSmartRow(sentinel, await this.tableMapper.getMap(), undefined);
         (smartRow as any)[SENTINEL_ROW] = true;
         return smartRow;
     }

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -247,9 +247,6 @@ export const muiDataGrid: Partial<TableConfig> = {
                         await header.click({ force: true });
                     }
                     
-                    // Sorting can trigger large re-renders/virtualization shifts
-                    await context.page.waitForTimeout(500); 
-                    
                     // Wait for stabilization (using DataGrid specific overlay check inside helper)
                     const displayedRows = context.root.locator('.MuiTablePagination-displayedRows');
                     const text = await displayedRows.innerText().catch(() => '');

--- a/tests/unit/mui.sort.test.ts
+++ b/tests/unit/mui.sort.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { muiDataGrid } from '../../src/presets/mui';
+
+describe('muiDataGrid.strategies.sorting.doSort — no fixed delay', () => {
+    it('does not call waitForTimeout with a fixed 500ms value', async () => {
+        const waitForTimeout = vi.fn().mockResolvedValue(undefined);
+
+        // Minimal MUI-like context: header with sort state toggling asc → desc on each click
+        let sortState = 'none';
+        const clickTarget = {
+            isVisible: vi.fn().mockResolvedValue(true),
+            click: vi.fn().mockImplementation(async () => { sortState = 'ascending'; }),
+        };
+        const header = {
+            locator: vi.fn().mockReturnValue({ first: vi.fn().mockReturnValue(clickTarget) }),
+            click: vi.fn(),
+            getAttribute: vi.fn().mockImplementation(() => sortState),
+        };
+
+        const stubLocator = {
+            count: vi.fn().mockResolvedValue(0),
+            isVisible: vi.fn().mockResolvedValue(false),
+            innerText: vi.fn().mockResolvedValue('1–10 of 10'),
+            waitFor: vi.fn().mockResolvedValue(undefined),
+            first: vi.fn().mockReturnThis(),
+        };
+
+        const context = {
+            page: { waitForTimeout },
+            root: { locator: vi.fn().mockReturnValue(stubLocator) },
+            getHeaderCell: vi.fn().mockResolvedValue(header),
+            config: {
+                strategies: {
+                    sorting: {
+                        getSortState: vi.fn().mockImplementation(() => sortState === 'ascending' ? 'asc' : 'none'),
+                    },
+                },
+            },
+        } as any;
+
+        const doSort = (muiDataGrid as any).strategies.sorting.doSort;
+        await doSort({ columnName: 'Name', direction: 'asc', context });
+
+        const fixedDelays = waitForTimeout.mock.calls.filter(([ms]) => ms === 500);
+        expect(fixedDelays).toHaveLength(0);
+    });
+});

--- a/tests/unit/rowFinder.unit.test.ts
+++ b/tests/unit/rowFinder.unit.test.ts
@@ -126,3 +126,29 @@ describe('RowFinder.findRow — isTableLoading polling', () => {
         expect(waitForTimeout).toHaveBeenCalledTimes(2); // once per "still loading" response
     });
 });
+
+// ─── findRow() sentinel row index ─────────────────────────────────────────────
+
+describe('RowFinder.findRow — sentinel row index', () => {
+    it('passes undefined rowIndex to makeSmartRow when row is not found', async () => {
+        const page = { waitForTimeout: vi.fn().mockResolvedValue(undefined) };
+        const root = makeMinimalRoot(page);
+        const noRows = { count: vi.fn().mockResolvedValue(0), all: vi.fn().mockResolvedValue([]), filter: vi.fn().mockReturnThis() };
+        const makeSmartRow = vi.fn().mockReturnValue({ rowIndex: undefined });
+
+        const finder = new RowFinder(
+            root,
+            makeConfig({ maxPages: 1 }),
+            vi.fn().mockReturnValue(noRows),
+            { applyFilters: vi.fn().mockReturnValue(noRows) } as any,
+            { getMap: vi.fn().mockResolvedValue(new Map([['id', 0]])) } as any,
+            makeSmartRow,
+        );
+
+        await finder.findRow({ id: 'missing' });
+
+        // Sentinel construction is the last makeSmartRow call; rowIndex must be undefined
+        const sentinelCall = makeSmartRow.mock.calls.at(-1);
+        expect(sentinelCall?.[2]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #322.

- **`src/presets/mui.ts`**: remove the fixed `waitForTimeout(500)` after each sort click in `muiDataGrid.strategies.sorting.doSort`. The 500ms delay was redundant — `waitForMuiPaginationStabilization` already waits for the overlay to clear and the pagination count to stabilize.
- **`src/engine/rowFinder.ts`**: fix not-found sentinel construction — `rowIndex` was `0` instead of `undefined`, which could cause `bringIntoView` to incorrectly navigate to page 0 on a sentinel row.

## Test plan

- [ ] `tests/unit/mui.sort.test.ts` — asserts `waitForTimeout(500)` is never called in `doSort`
- [ ] `tests/unit/rowFinder.unit.test.ts` — asserts sentinel `makeSmartRow` call receives `undefined` rowIndex
- [ ] `pnpm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MUI DataGrid sorting responsiveness by removing fixed wait times and implementing smart stabilization detection for pagination and rendering.
  * Improved row-finding logic for better handling when rows cannot be located.

* **Tests**
  * Added unit tests verifying sorting behavior no longer relies on fixed delays and validating row-finding behavior for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->