### PR TITLE
fix(ci): create metrics/ dir before writing history.json

### DIFF
--- a/scripts/collect-metrics.mjs
+++ b/scripts/collect-metrics.mjs
@@ -139,6 +139,7 @@ history.sort((a, b) => {
     return 0;
 });
 
+fs.mkdirSync(path.dirname(historyPath), { recursive: true });
 fs.writeFileSync(historyPath, JSON.stringify(history, null, 2) + '\n');
 
 // ── Console summary ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `writeFileSync` throws `ENOENT` when `metrics/` doesn't exist on a fresh CI runner
- Adding `mkdirSync` with `recursive: true` before the write ensures the directory is always present

## Root cause

The `collect-metrics.mjs` script assumes `metrics/history.json` exists or that the `metrics/` directory already exists. On a fresh clone (every CI run), neither is true, so `writeFileSync` fails with `ENOENT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)