### PR TITLE
feat: add mergeTableConfig() for composing base + override configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **`table.toArray()`** — shorthand for `map()` + `reset()`. Accepts an optional callback (defaults to `row.toJSON()`) and the same options as `map()`. Calls `reset()` in a `finally` block so the table always lands on page 1. Closes #336.
+- **`mergeTableConfig(base, overrides)`** — utility for composing a shared base config with per-table overrides. Deep-merges `strategies` and `columnOverrides` sub-keys; shallow-merges everything else. Closes #337.
 
 ## [6.16.0] - 2026-06-24
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,5 @@ export * as presets from './presets';
 
 /** @deprecated Use `presets` instead. Plugins will be removed in v7.0.0. */
 export { Plugins } from './plugins';
+
+export { mergeTableConfig } from './utils/mergeTableConfig';

--- a/src/utils/mergeTableConfig.ts
+++ b/src/utils/mergeTableConfig.ts
@@ -1,0 +1,71 @@
+import type { TableConfig } from '../types';
+
+/**
+ * Deep-merges two `TableConfig` objects.
+ *
+ * Merge semantics:
+ * - Top-level keys (`rowSelector`, `maxPages`, etc.): overrides win — same as `{ ...base, ...overrides }`.
+ * - `strategies`: each sub-key is merged independently. Strategy sub-objects (`loading`, `viewport`)
+ *   are merged key-by-key so that neither side silently wipes the other's settings.
+ *   Function-valued strategies (`pagination`, `header`, `dedupe`, `getCellLocator`, etc.) are
+ *   replaced in full by the override value (a function cannot be meaningfully object-spread).
+ * - `columnOverrides`: merged key-by-key (each column entry merged independently).
+ * - Everything else: overrides win (shallow merge).
+ *
+ * @example
+ * const config = mergeTableConfig(baseConfig, {
+ *   maxPages: 20,
+ *   strategies: {
+ *     loading: { isTableLoading: myLoadingFn },
+ *   },
+ * });
+ */
+export function mergeTableConfig<T = any>(
+    base: TableConfig<T>,
+    overrides: TableConfig<T>
+): TableConfig<T> {
+    const result: TableConfig<T> = { ...base, ...overrides };
+
+    // Deep-merge strategies one level down
+    if (base.strategies || overrides.strategies) {
+        result.strategies = {
+            ...base.strategies,
+            ...overrides.strategies,
+        };
+
+        // For strategy sub-keys that are plain objects on *both* sides, merge key-by-key
+        // so that e.g. base.strategies.loading and overrides.strategies.loading are combined.
+        // Function values (pagination, header, dedupe, getCellLocator, etc.) are replaced, not merged.
+        const strategyKeys = new Set([
+            ...Object.keys(base.strategies ?? {}),
+            ...Object.keys(overrides.strategies ?? {}),
+        ]) as Set<keyof NonNullable<TableConfig<T>['strategies']>>;
+
+        for (const key of strategyKeys) {
+            const baseVal = base.strategies?.[key];
+            const overrideVal = overrides.strategies?.[key];
+            if (
+                baseVal !== undefined &&
+                overrideVal !== undefined &&
+                typeof baseVal === 'object' &&
+                typeof overrideVal === 'object' &&
+                !Array.isArray(baseVal) &&
+                !Array.isArray(overrideVal) &&
+                typeof baseVal !== 'function' &&
+                typeof overrideVal !== 'function'
+            ) {
+                (result.strategies as any)[key] = { ...baseVal, ...overrideVal };
+            }
+        }
+    }
+
+    // Deep-merge columnOverrides one level down (each column entry merged independently)
+    if (base.columnOverrides || overrides.columnOverrides) {
+        result.columnOverrides = {
+            ...base.columnOverrides,
+            ...overrides.columnOverrides,
+        } as TableConfig<T>['columnOverrides'];
+    }
+
+    return result;
+}

--- a/src/utils/mergeTableConfig.ts
+++ b/src/utils/mergeTableConfig.ts
@@ -5,10 +5,10 @@ import type { TableConfig } from '../types';
  *
  * Merge semantics:
  * - Top-level keys (`rowSelector`, `maxPages`, etc.): overrides win — same as `{ ...base, ...overrides }`.
- * - `strategies`: each sub-key is merged independently. Strategy sub-objects (`loading`, `viewport`)
- *   are merged key-by-key so that neither side silently wipes the other's settings.
- *   Function-valued strategies (`pagination`, `header`, `dedupe`, `getCellLocator`, etc.) are
- *   replaced in full by the override value (a function cannot be meaningfully object-spread).
+ * - `strategies`: each sub-key is merged independently. Object-valued strategies (`loading`,
+ *   `viewport`, `pagination`) are merged key-by-key so that neither side silently wipes the
+ *   other's settings. Function-valued strategies (`header`, `dedupe`, `getCellLocator`, etc.)
+ *   are replaced in full by the override value (a function cannot be meaningfully object-spread).
  * - `columnOverrides`: merged key-by-key (each column entry merged independently).
  * - Everything else: overrides win (shallow merge).
  *
@@ -54,7 +54,10 @@ export function mergeTableConfig<T = any>(
                 typeof baseVal !== 'function' &&
                 typeof overrideVal !== 'function'
             ) {
-                (result.strategies as any)[key] = { ...baseVal, ...overrideVal };
+                // The spread result can't be expressed as the union of all strategy types;
+                // the runtime object-check above guarantees safety.
+                (result.strategies as NonNullable<TableConfig<T>['strategies']>)[key] =
+                    { ...baseVal, ...overrideVal } as never;
             }
         }
     }

--- a/tests/unit/mergeTableConfig.test.ts
+++ b/tests/unit/mergeTableConfig.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mergeTableConfig } from '../../src/utils/mergeTableConfig';
+import type { TableConfig } from '../../src/types';
+
+describe('mergeTableConfig', () => {
+    it('top-level scalar overrides win', () => {
+        const base: TableConfig = { rowSelector: 'tr', maxPages: 5 };
+        const overrides: TableConfig = { maxPages: 20 };
+        const result = mergeTableConfig(base, overrides);
+        expect(result.rowSelector).toBe('tr');
+        expect(result.maxPages).toBe(20);
+    });
+
+    it('top-level keys present only in base are preserved', () => {
+        const base: TableConfig = { rowSelector: 'tr', maxPages: 5, autoScroll: true };
+        const overrides: TableConfig = { maxPages: 10 };
+        const result = mergeTableConfig(base, overrides);
+        expect(result.autoScroll).toBe(true);
+    });
+
+    it('top-level keys present only in overrides are included', () => {
+        const base: TableConfig = { maxPages: 5 };
+        const overrides: TableConfig = { rowSelector: 'tbody tr' };
+        const result = mergeTableConfig(base, overrides);
+        expect(result.rowSelector).toBe('tbody tr');
+        expect(result.maxPages).toBe(5);
+    });
+
+    describe('strategies deep-merge', () => {
+        it('merges loading sub-object key-by-key', () => {
+            const isTableLoading = vi.fn();
+            const isHeaderLoading = vi.fn();
+
+            const base: TableConfig = {
+                strategies: {
+                    loading: { isTableLoading, rowLoadingTimeout: 3000 },
+                },
+            };
+            const overrides: TableConfig = {
+                strategies: {
+                    loading: { isHeaderLoading },
+                },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.loading?.isTableLoading).toBe(isTableLoading);
+            expect(result.strategies?.loading?.isHeaderLoading).toBe(isHeaderLoading);
+            expect(result.strategies?.loading?.rowLoadingTimeout).toBe(3000);
+        });
+
+        it('override loading keys win over base loading keys', () => {
+            const baseLoading = vi.fn();
+            const overrideLoading = vi.fn();
+
+            const base: TableConfig = {
+                strategies: {
+                    loading: { isTableLoading: baseLoading, rowLoadingTimeout: 1000 },
+                },
+            };
+            const overrides: TableConfig = {
+                strategies: {
+                    loading: { isTableLoading: overrideLoading, rowLoadingTimeout: 5000 },
+                },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.loading?.isTableLoading).toBe(overrideLoading);
+            expect(result.strategies?.loading?.rowLoadingTimeout).toBe(5000);
+        });
+
+        it('merges viewport sub-object key-by-key', () => {
+            const getVisibleRowRange = vi.fn();
+            const scrollToRow = vi.fn();
+
+            const base: TableConfig = {
+                strategies: { viewport: { getVisibleRowRange } },
+            };
+            const overrides: TableConfig = {
+                strategies: { viewport: { scrollToRow } },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.viewport?.getVisibleRowRange).toBe(getVisibleRowRange);
+            expect(result.strategies?.viewport?.scrollToRow).toBe(scrollToRow);
+        });
+
+        it('function-valued strategies are replaced, not merged', () => {
+            const basePagination = { goNext: vi.fn(), goNextBulk: vi.fn() };
+            const overridePagination = { goNext: vi.fn() };
+
+            const base: TableConfig = {
+                strategies: { pagination: basePagination as any },
+            };
+            const overrides: TableConfig = {
+                strategies: { pagination: overridePagination as any },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            // pagination is a plain object, so it should be merged like other plain objects
+            // Actually pagination is an object with function values — it is itself an object
+            // and should be deep-merged. Let's verify override wins the goNext key:
+            expect(result.strategies?.pagination).toBeDefined();
+        });
+
+        it('function strategy (getCellLocator) is replaced by override', () => {
+            const baseFn = vi.fn();
+            const overrideFn = vi.fn();
+
+            const base: TableConfig = {
+                strategies: { getCellLocator: baseFn },
+            };
+            const overrides: TableConfig = {
+                strategies: { getCellLocator: overrideFn },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.getCellLocator).toBe(overrideFn);
+        });
+
+        it('base strategies not in overrides are preserved', () => {
+            const isTableLoading = vi.fn();
+            const getCellLocator = vi.fn();
+
+            const base: TableConfig = {
+                strategies: {
+                    loading: { isTableLoading },
+                    getCellLocator,
+                },
+            };
+            const overrides: TableConfig = {
+                strategies: {
+                    loading: { rowLoadingTimeout: 2000 },
+                },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.getCellLocator).toBe(getCellLocator);
+            expect(result.strategies?.loading?.isTableLoading).toBe(isTableLoading);
+            expect(result.strategies?.loading?.rowLoadingTimeout).toBe(2000);
+        });
+
+        it('strategies only in base returns correct result', () => {
+            const isTableLoading = vi.fn();
+            const base: TableConfig = {
+                strategies: { loading: { isTableLoading } },
+            };
+            const overrides: TableConfig = {};
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.loading?.isTableLoading).toBe(isTableLoading);
+        });
+
+        it('strategies only in overrides returns correct result', () => {
+            const isTableLoading = vi.fn();
+            const base: TableConfig = {};
+            const overrides: TableConfig = {
+                strategies: { loading: { isTableLoading } },
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.strategies?.loading?.isTableLoading).toBe(isTableLoading);
+        });
+    });
+
+    describe('columnOverrides deep-merge', () => {
+        it('merges column entries from both sides', () => {
+            const base: TableConfig = {
+                columnOverrides: {
+                    Name: { read: async (cell) => (await cell.textContent()) ?? '' },
+                } as any,
+            };
+            const overrides: TableConfig = {
+                columnOverrides: {
+                    Status: { read: async (cell) => (await cell.textContent()) ?? '' },
+                } as any,
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect(result.columnOverrides).toHaveProperty('Name');
+            expect(result.columnOverrides).toHaveProperty('Status');
+        });
+
+        it('override column entry wins over base for the same column', () => {
+            const baseRead = vi.fn();
+            const overrideRead = vi.fn();
+
+            const base: TableConfig = {
+                columnOverrides: { Name: { read: baseRead } } as any,
+            };
+            const overrides: TableConfig = {
+                columnOverrides: { Name: { read: overrideRead } } as any,
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect((result.columnOverrides as any)?.Name?.read).toBe(overrideRead);
+        });
+
+        it('columnOverrides only in base are preserved', () => {
+            const read = vi.fn();
+            const base: TableConfig = {
+                columnOverrides: { Name: { read } } as any,
+            };
+            const overrides: TableConfig = {};
+
+            const result = mergeTableConfig(base, overrides);
+            expect((result.columnOverrides as any)?.Name?.read).toBe(read);
+        });
+
+        it('columnOverrides only in overrides are included', () => {
+            const read = vi.fn();
+            const base: TableConfig = {};
+            const overrides: TableConfig = {
+                columnOverrides: { Name: { read } } as any,
+            };
+
+            const result = mergeTableConfig(base, overrides);
+            expect((result.columnOverrides as any)?.Name?.read).toBe(read);
+        });
+    });
+
+    describe('mutation safety', () => {
+        it('does not mutate the base config', () => {
+            const isTableLoading = vi.fn();
+            const base: TableConfig = {
+                maxPages: 5,
+                strategies: { loading: { isTableLoading } },
+            };
+            const overrides: TableConfig = {
+                maxPages: 10,
+                strategies: { loading: { rowLoadingTimeout: 1000 } },
+            };
+
+            mergeTableConfig(base, overrides);
+
+            expect(base.maxPages).toBe(5);
+            expect(base.strategies?.loading?.rowLoadingTimeout).toBeUndefined();
+        });
+
+        it('does not mutate the overrides config', () => {
+            const isHeaderLoading = vi.fn();
+            const base: TableConfig = {
+                strategies: { loading: { rowLoadingTimeout: 500 } },
+            };
+            const overrides: TableConfig = {
+                strategies: { loading: { isHeaderLoading } },
+            };
+
+            mergeTableConfig(base, overrides);
+
+            expect(overrides.strategies?.loading?.rowLoadingTimeout).toBeUndefined();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns a new object (not the same reference as base or overrides)', () => {
+            const base: TableConfig = { maxPages: 1 };
+            const overrides: TableConfig = { maxPages: 2 };
+            const result = mergeTableConfig(base, overrides);
+            expect(result).not.toBe(base);
+            expect(result).not.toBe(overrides);
+        });
+
+        it('handles empty base and empty overrides', () => {
+            const result = mergeTableConfig({}, {});
+            expect(result).toEqual({});
+        });
+
+        it('handles empty base', () => {
+            const base: TableConfig = {};
+            const overrides: TableConfig = { maxPages: 5, rowSelector: 'tr' };
+            const result = mergeTableConfig(base, overrides);
+            expect(result.maxPages).toBe(5);
+            expect(result.rowSelector).toBe('tr');
+        });
+
+        it('handles empty overrides', () => {
+            const base: TableConfig = { maxPages: 5, rowSelector: 'tr' };
+            const overrides: TableConfig = {};
+            const result = mergeTableConfig(base, overrides);
+            expect(result.maxPages).toBe(5);
+            expect(result.rowSelector).toBe('tr');
+        });
+    });
+});

--- a/tests/unit/mergeTableConfig.test.ts
+++ b/tests/unit/mergeTableConfig.test.ts
@@ -84,7 +84,7 @@ describe('mergeTableConfig', () => {
             expect(result.strategies?.viewport?.scrollToRow).toBe(scrollToRow);
         });
 
-        it('function-valued strategies are replaced, not merged', () => {
+        it('object-valued strategies (pagination) are merged key-by-key', () => {
             const basePagination = { goNext: vi.fn(), goNextBulk: vi.fn() };
             const overridePagination = { goNext: vi.fn() };
 
@@ -96,10 +96,9 @@ describe('mergeTableConfig', () => {
             };
 
             const result = mergeTableConfig(base, overrides);
-            // pagination is a plain object, so it should be merged like other plain objects
-            // Actually pagination is an object with function values — it is itself an object
-            // and should be deep-merged. Let's verify override wins the goNext key:
-            expect(result.strategies?.pagination).toBeDefined();
+            // override's goNext wins; base's goNextBulk is preserved
+            expect(result.strategies?.pagination?.goNext).toBe(overridePagination.goNext);
+            expect(result.strategies?.pagination?.goNextBulk).toBe(basePagination.goNextBulk);
         });
 
         it('function strategy (getCellLocator) is replaced by override', () => {


### PR DESCRIPTION
## Summary

- Adds `mergeTableConfig(base, overrides)` utility to `src/utils/mergeTableConfig.ts`
- Exports it from `src/index.ts` as a named export
- Deep-merges `strategies` sub-objects (`loading`, `viewport`) key-by-key — neither side silently wipes the other
- Function-valued strategies (`getCellLocator`, `beforeCellRead`, etc.) are replaced by the override (can't be object-spread)
- `columnOverrides` merged entry-by-entry
- All other top-level keys: overrides win (shallow merge)
- 21 unit tests covering all merge paths, mutation safety, and edge cases
- `CHANGELOG.md` updated under `[Unreleased]`

Closes #337.

## Test plan

- [x] `npx vitest run tests/unit/mergeTableConfig.test.ts` — 21 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `pnpm run build` — passes (run by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration merge utility for combining a shared base setup with per-table overrides.
  * The merge behavior now preserves existing settings while letting overrides take precedence, including deeper handling for strategy and column-specific settings.

* **Documentation**
  * Updated the changelog to note the new merge utility.

* **Tests**
  * Added coverage for merge behavior, override precedence, empty inputs, and ensuring original inputs are not modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->