### PR TITLE
feat(presets): add MUI factories, muiDataGrid.goToFirst, fix RDG typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### Added
 - **`table.toArray()`** — shorthand for `map()` + `reset()`. Accepts an optional callback (defaults to `row.toJSON()`) and the same options as `map()`. Calls `reset()` in a `finally` block so the table always lands on page 1. Closes #336.
 - **`mergeTableConfig(base, overrides)`** — utility for composing a shared base config with per-table overrides. Deep-merges `strategies` and `columnOverrides` sub-keys; shallow-merges everything else. Closes #337.
+- **`createMuiTable(opts?)` / `createMuiDataGrid(opts?)`** — factory functions for the MUI presets. Accept `{ buttonLabels }` to override pagination button aria-labels for non-English locales. The static `muiTable` / `muiDataGrid` exports are unchanged and use English defaults. Closes #327 (v6 parts).
+- **`muiDataGrid.goToFirst`** — MUI DataGrid now supports `goToFirst` (tries the first-page button, falls back to stepping backward). Previously absent.
+- **`MuiButtonLabels`** — exported interface for the button label overrides accepted by `createMuiTable` and `createMuiDataGrid`.
+
+### Fixed
+- **`muiTable.goToFirst`** — now checks for an explicit "Go to first page" button (MUI's `showFirstButton` prop) before falling back to the step-backward loop.
+
+### Changed
+- **RDG navigation typing** — `rdgNavigation` functions and `rdgGetCellLocator` no longer use `any`; properly typed as `StrategyContext` and `{ row: Locator; columnIndex: number }` respectively.
 
 ## [6.16.0] - 2026-06-24
 

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,4 +1,5 @@
-export { muiTable, muiDataGrid } from './mui';
+export { muiTable, muiDataGrid, createMuiTable, createMuiDataGrid } from './mui';
+export type { MuiButtonLabels } from './mui';
 export { RDG as rdg, RDG2D as rdg2D } from './rdg';
 export { Glide as glide, createGlide, createGlideViewport } from './glide';
 export type { GlideOptions, GlideViewportOptions } from './glide';

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -83,7 +83,7 @@ export function createMuiTable(opts?: { buttonLabels?: MuiButtonLabels }): Parti
         pagination: {
             goNext: async (context) => {
                 const root = await getPaginationRoot(context);
-                const nextBtn = root.locator(`button[aria-label="${labels.nextPage}"]`);
+                const nextBtn = root.getByRole('button', { name: labels.nextPage, exact: true });
                 if (await nextBtn.count() === 0 || await nextBtn.isDisabled()) return false;
 
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
@@ -96,7 +96,7 @@ export function createMuiTable(opts?: { buttonLabels?: MuiButtonLabels }): Parti
             },
             goPrevious: async (context) => {
                 const root = await getPaginationRoot(context);
-                const prevBtn = root.locator(`button[aria-label="${labels.previousPage}"]`);
+                const prevBtn = root.getByRole('button', { name: labels.previousPage, exact: true });
                 if (await prevBtn.count() === 0 || await prevBtn.isDisabled()) return false;
 
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
@@ -111,7 +111,7 @@ export function createMuiTable(opts?: { buttonLabels?: MuiButtonLabels }): Parti
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
 
                 // MUI TablePagination optionally renders a "first page" button (showFirstButton prop)
-                const firstBtn = root.locator(`button[aria-label="${labels.firstPage}"]`);
+                const firstBtn = root.getByRole('button', { name: labels.firstPage, exact: true });
                 if (await firstBtn.count() > 0 && !(await firstBtn.isDisabled())) {
                     const oldText = await displayedRows.innerText().catch(() => '');
                     await firstBtn.click({ force: true });
@@ -120,14 +120,14 @@ export function createMuiTable(opts?: { buttonLabels?: MuiButtonLabels }): Parti
                 }
 
                 // Fall back to stepping backward one page at a time
-                const prevBtn = root.locator(`button[aria-label="${labels.previousPage}"]`);
+                const prevBtn = root.getByRole('button', { name: labels.previousPage, exact: true });
                 let clicked = false;
                 let noProgressCount = 0;
                 const NO_PROGRESS_LIMIT = 3;
 
                 while (await prevBtn.count() > 0 && !(await prevBtn.isDisabled())) {
                     const oldText = await displayedRows.innerText().catch(() => '');
-                    await prevBtn.click();
+                    await prevBtn.click({ force: true });
                     await waitForMuiPaginationStabilization(context, displayedRows, oldText);
                     clicked = true;
 
@@ -217,7 +217,7 @@ export function createMuiDataGrid(opts?: { buttonLabels?: MuiButtonLabels }): Pa
         pagination: {
             goNext: async (context) => {
                 const footer = context.root.locator('.MuiDataGrid-footerContainer');
-                const nextBtn = footer.locator(`button[aria-label="${labels.nextPage}"]`);
+                const nextBtn = footer.getByRole('button', { name: labels.nextPage, exact: true });
 
                 try {
                     await nextBtn.waitFor({ state: 'visible', timeout: 2000 });
@@ -237,7 +237,7 @@ export function createMuiDataGrid(opts?: { buttonLabels?: MuiButtonLabels }): Pa
             },
             goPrevious: async (context) => {
                 const footer = context.root.locator('.MuiDataGrid-footerContainer');
-                const prevBtn = footer.locator(`button[aria-label="${labels.previousPage}"]`);
+                const prevBtn = footer.getByRole('button', { name: labels.previousPage, exact: true });
 
                 try {
                     await prevBtn.waitFor({ state: 'visible', timeout: 2000 });
@@ -259,7 +259,7 @@ export function createMuiDataGrid(opts?: { buttonLabels?: MuiButtonLabels }): Pa
                 const footer = context.root.locator('.MuiDataGrid-footerContainer');
                 const displayedRows = footer.locator('.MuiTablePagination-displayedRows');
 
-                const firstBtn = footer.locator(`button[aria-label="${labels.firstPage}"]`);
+                const firstBtn = footer.getByRole('button', { name: labels.firstPage, exact: true });
                 try {
                     await firstBtn.waitFor({ state: 'visible', timeout: 1000 });
                     if (!(await firstBtn.isDisabled())) {
@@ -273,7 +273,7 @@ export function createMuiDataGrid(opts?: { buttonLabels?: MuiButtonLabels }): Pa
                     // first-page button not present; fall back to stepping backward
                 }
 
-                const prevBtn = footer.locator(`button[aria-label="${labels.previousPage}"]`);
+                const prevBtn = footer.getByRole('button', { name: labels.previousPage, exact: true });
                 let clicked = false;
                 let noProgressCount = 0;
                 const NO_PROGRESS_LIMIT = 3;

--- a/src/presets/mui.ts
+++ b/src/presets/mui.ts
@@ -3,6 +3,19 @@ import { TableConfig, TableContext } from '../types';
 import { PaginationStrategies } from '../strategies';
 import { logDebug } from '../utils/debugUtils';
 
+/** Aria-labels for MUI pagination buttons. Override for non-English locales. */
+export interface MuiButtonLabels {
+    nextPage?: string;
+    previousPage?: string;
+    firstPage?: string;
+}
+
+const DEFAULT_LABELS: Required<MuiButtonLabels> = {
+    nextPage: 'Go to next page',
+    previousPage: 'Go to previous page',
+    firstPage: 'Go to first page',
+};
+
 /** 
  * Safely wait for MUI pagination to stabilize.
  * Polls for displayed row text changes and waits for loading overlays to disappear.
@@ -49,15 +62,17 @@ async function getPaginationRoot(context: TableContext) {
 }
 
 /**
- * Preset configuration for the standard Material UI `<Table />` component.
- * 
- * Handles:
- * - Selectors for `.MuiTableRow-root`, `.MuiTableCell-head`, etc.
- * - Pagination via the standard `.MuiTablePagination-actions` footer.
- * - Sorting via the `.MuiTableSortLabel-root` header classes.
- * - Virtualized DOM deduplication (falls back to cell text if unvirtualized).
+ * Creates a preset configuration for the standard Material UI `<Table />` component.
+ *
+ * @param opts.buttonLabels - Override aria-labels for pagination buttons (use for non-English locales).
+ *
+ * @example
+ * // French locale
+ * const table = useTable(loc, createMuiTable({ buttonLabels: { nextPage: 'Page suivante', previousPage: 'Page précédente' } }));
  */
-export const muiTable: Partial<TableConfig> = {
+export function createMuiTable(opts?: { buttonLabels?: MuiButtonLabels }): Partial<TableConfig> {
+    const labels = { ...DEFAULT_LABELS, ...opts?.buttonLabels };
+    return {
     rowSelector: 'tbody tr, tbody .MuiTableRow-root',
     cellSelector: 'td, th, .MuiTableCell-body',
     headerSelector: 'thead th, .MuiTableCell-head',
@@ -68,7 +83,7 @@ export const muiTable: Partial<TableConfig> = {
         pagination: {
             goNext: async (context) => {
                 const root = await getPaginationRoot(context);
-                const nextBtn = root.locator('button[aria-label="Go to next page"]');
+                const nextBtn = root.locator(`button[aria-label="${labels.nextPage}"]`);
                 if (await nextBtn.count() === 0 || await nextBtn.isDisabled()) return false;
 
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
@@ -81,7 +96,7 @@ export const muiTable: Partial<TableConfig> = {
             },
             goPrevious: async (context) => {
                 const root = await getPaginationRoot(context);
-                const prevBtn = root.locator('button[aria-label="Go to previous page"]');
+                const prevBtn = root.locator(`button[aria-label="${labels.previousPage}"]`);
                 if (await prevBtn.count() === 0 || await prevBtn.isDisabled()) return false;
 
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
@@ -93,9 +108,19 @@ export const muiTable: Partial<TableConfig> = {
             },
             goToFirst: async (context) => {
                 const root = await getPaginationRoot(context);
-                const prevBtn = root.locator('button[aria-label="Go to previous page"]');
                 const displayedRows = root.locator('.MuiTablePagination-displayedRows');
 
+                // MUI TablePagination optionally renders a "first page" button (showFirstButton prop)
+                const firstBtn = root.locator(`button[aria-label="${labels.firstPage}"]`);
+                if (await firstBtn.count() > 0 && !(await firstBtn.isDisabled())) {
+                    const oldText = await displayedRows.innerText().catch(() => '');
+                    await firstBtn.click({ force: true });
+                    await waitForMuiPaginationStabilization(context, displayedRows, oldText);
+                    return true;
+                }
+
+                // Fall back to stepping backward one page at a time
+                const prevBtn = root.locator(`button[aria-label="${labels.previousPage}"]`);
                 let clicked = false;
                 let noProgressCount = 0;
                 const NO_PROGRESS_LIMIT = 3;
@@ -163,11 +188,17 @@ export const muiTable: Partial<TableConfig> = {
             return text || String(Math.random());
         }
     }
-};
+    };
+}
+
+/** Default preset for MUI `<Table />`. For non-English locales use `createMuiTable({ buttonLabels })`. */
+export const muiTable: Partial<TableConfig> = createMuiTable();
 
 /**
- * Preset configuration for the MUI DataGrid component (@mui/x-data-grid).
- * 
+ * Creates a preset configuration for the MUI DataGrid component (@mui/x-data-grid).
+ *
+ * @param opts.buttonLabels - Override aria-labels for pagination buttons (use for non-English locales).
+ *
  * Handles:
  * - Selectors for `.MuiDataGrid-row`, `.MuiDataGrid-cell`, and `.MuiDataGrid-columnHeader`.
  * - Pagination via the `.MuiDataGrid-footerContainer` (handling React's async rendering).
@@ -175,7 +206,9 @@ export const muiTable: Partial<TableConfig> = {
  * - Vertical Virtualization deduplication using `data-rowindex`.
  * - Horizontal Virtualization support via `aria-colindex`.
  */
-export const muiDataGrid: Partial<TableConfig> = {
+export function createMuiDataGrid(opts?: { buttonLabels?: MuiButtonLabels }): Partial<TableConfig> {
+    const labels = { ...DEFAULT_LABELS, ...opts?.buttonLabels };
+    return {
     rowSelector: '.MuiDataGrid-row',
     cellSelector: '.MuiDataGrid-cell',
     headerSelector: '.MuiDataGrid-columnHeader',
@@ -184,8 +217,8 @@ export const muiDataGrid: Partial<TableConfig> = {
         pagination: {
             goNext: async (context) => {
                 const footer = context.root.locator('.MuiDataGrid-footerContainer');
-                const nextBtn = footer.locator('button[aria-label="Go to next page"]');
-                
+                const nextBtn = footer.locator(`button[aria-label="${labels.nextPage}"]`);
+
                 try {
                     await nextBtn.waitFor({ state: 'visible', timeout: 2000 });
                 } catch (e) {
@@ -204,8 +237,8 @@ export const muiDataGrid: Partial<TableConfig> = {
             },
             goPrevious: async (context) => {
                 const footer = context.root.locator('.MuiDataGrid-footerContainer');
-                const prevBtn = footer.locator('button[aria-label="Go to previous page"]');
-                
+                const prevBtn = footer.locator(`button[aria-label="${labels.previousPage}"]`);
+
                 try {
                     await prevBtn.waitFor({ state: 'visible', timeout: 2000 });
                 } catch (e) {
@@ -221,6 +254,56 @@ export const muiDataGrid: Partial<TableConfig> = {
                 await prevBtn.click({ force: true });
                 await waitForMuiPaginationStabilization(context, displayedRows, oldText);
                 return true;
+            },
+            goToFirst: async (context) => {
+                const footer = context.root.locator('.MuiDataGrid-footerContainer');
+                const displayedRows = footer.locator('.MuiTablePagination-displayedRows');
+
+                const firstBtn = footer.locator(`button[aria-label="${labels.firstPage}"]`);
+                try {
+                    await firstBtn.waitFor({ state: 'visible', timeout: 1000 });
+                    if (!(await firstBtn.isDisabled())) {
+                        const oldText = await displayedRows.innerText().catch(() => '');
+                        await firstBtn.scrollIntoViewIfNeeded().catch(() => {});
+                        await firstBtn.click({ force: true });
+                        await waitForMuiPaginationStabilization(context, displayedRows, oldText);
+                        return true;
+                    }
+                } catch {
+                    // first-page button not present; fall back to stepping backward
+                }
+
+                const prevBtn = footer.locator(`button[aria-label="${labels.previousPage}"]`);
+                let clicked = false;
+                let noProgressCount = 0;
+                const NO_PROGRESS_LIMIT = 3;
+
+                while (true) {
+                    try {
+                        await prevBtn.waitFor({ state: 'visible', timeout: 2000 });
+                    } catch {
+                        break;
+                    }
+                    if (await prevBtn.isDisabled()) break;
+
+                    const oldText = await displayedRows.innerText().catch(() => '');
+                    await prevBtn.scrollIntoViewIfNeeded().catch(() => {});
+                    await prevBtn.click({ force: true });
+                    await waitForMuiPaginationStabilization(context, displayedRows, oldText);
+                    clicked = true;
+
+                    const newText = await displayedRows.innerText().catch(() => '');
+                    if (newText === oldText) {
+                        noProgressCount++;
+                        if (noProgressCount >= NO_PROGRESS_LIMIT) {
+                            logDebug(context.config, 'error', `goToFirst: no pagination progress after ${NO_PROGRESS_LIMIT} consecutive clicks — aborting to avoid infinite loop`);
+                            return false;
+                        }
+                    } else {
+                        noProgressCount = 0;
+                    }
+                }
+                return clicked;
             }
         },
         sorting: {
@@ -351,4 +434,8 @@ export const muiDataGrid: Partial<TableConfig> = {
             }
         }
     }
-};
+    };
+}
+
+/** Default preset for MUI DataGrid. For non-English locales use `createMuiDataGrid({ buttonLabels })`. */
+export const muiDataGrid: Partial<TableConfig> = createMuiDataGrid();

--- a/src/presets/rdg.ts
+++ b/src/presets/rdg.ts
@@ -1,4 +1,5 @@
-import { TableContext, Selector, TableConfig, ViewportStrategy } from '../types';
+import type { Locator } from '@playwright/test';
+import { TableContext, Selector, TableConfig, ViewportStrategy, StrategyContext } from '../types';
 import { PaginationStrategies } from '../strategies/pagination';
 import { StabilizationStrategies } from '../strategies/stabilization';
 
@@ -61,7 +62,7 @@ const scrollRightHeaderRDG = async (context: TableContext) => {
     return Array.from(collectedHeaders);
 };
 
-const rdgGetCellLocator = ({ row, columnIndex }: any) => {
+const rdgGetCellLocator = ({ row, columnIndex }: { row: Locator; columnIndex: number }) => {
     const ariaColIndex = columnIndex + 1;
     return row.locator(`[role="gridcell"][aria-colindex="${ariaColIndex}"]`);
 };
@@ -73,36 +74,36 @@ const rdgPaginationStrategy = PaginationStrategies.infiniteScroll({
 });
 
 const rdgNavigation = {
-    goRight: async ({ root, page }: any) => {
+    goRight: async ({ root }: StrategyContext) => {
         await root.evaluate((el: HTMLElement) => {
             const grid = el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el;
-            if (grid) grid.scrollLeft += 150;
+            if (grid) (grid as HTMLElement).scrollLeft += 150;
         });
     },
-    goLeft: async ({ root, page }: any) => {
+    goLeft: async ({ root }: StrategyContext) => {
         await root.evaluate((el: HTMLElement) => {
             const grid = el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el;
-            if (grid) grid.scrollLeft -= 150;
+            if (grid) (grid as HTMLElement).scrollLeft -= 150;
         });
     },
-    goDown: async ({ root, page }: any) => {
+    goDown: async ({ root }: StrategyContext) => {
         await root.evaluate((el: HTMLElement) => {
             const grid = el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el;
-            if (grid) grid.scrollTop += 35;
+            if (grid) (grid as HTMLElement).scrollTop += 35;
         });
     },
-    goUp: async ({ root, page }: any) => {
+    goUp: async ({ root }: StrategyContext) => {
         await root.evaluate((el: HTMLElement) => {
             const grid = el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el;
-            if (grid) grid.scrollTop -= 35;
+            if (grid) (grid as HTMLElement).scrollTop -= 35;
         });
     },
-    goHome: async ({ root, page }: any) => {
+    goHome: async ({ root }: StrategyContext) => {
         await root.evaluate((el: HTMLElement) => {
             const grid = el.querySelector('[role="grid"]') || el.closest('[role="grid"]') || el;
             if (grid) {
-                grid.scrollLeft = 0;
-                grid.scrollTop = 0;
+                (grid as HTMLElement).scrollLeft = 0;
+                (grid as HTMLElement).scrollTop = 0;
             }
         });
     }


### PR DESCRIPTION
## Summary

- **`createMuiTable(opts?)` / `createMuiDataGrid(opts?)`** — factory functions accepting `{ buttonLabels }` for non-English locales; static `muiTable` / `muiDataGrid` are now the default-label results of these factories (no breaking change)
- **`muiDataGrid.goToFirst`** — was missing entirely; now tries the first-page button then falls back to stepping backward
- **`muiTable.goToFirst`** — checks for `showFirstButton` first-page button before the step-backward loop
- **`MuiButtonLabels`** exported interface
- **RDG typing** — `rdgNavigation` and `rdgGetCellLocator` replace `any` with `StrategyContext` / `{ row: Locator; columnIndex: number }`

Closes #327 (v6 parts). Breaking removals (old export names) deferred to v7.

## Test plan

- [ ] `muiTable` / `muiDataGrid` static exports behave identically to before (English defaults)
- [ ] `createMuiTable({ buttonLabels: { nextPage: '...' } })` produces a preset with the overridden label wired into all button locators
- [ ] `muiDataGrid.goToFirst` navigates to page 1 in the MUI DataGrid integration tests
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable button labels for MUI table and data grid navigation, including support for jumping to the first page.
  * Exposed new preset factory options so pagination text can be tailored to different UI labels.

* **Bug Fixes**
  * Improved “go to first page” behavior to prefer a direct first-page button when available, with a reliable fallback.
  * Strengthened grid navigation handling and typing for more stable, predictable interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->