### PR TITLE
fix(ci): support major-only version tags in Dependabot auto-merge regex

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,9 +26,11 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
             const body = pr.data.body || '';
-            // Matches both semver (1.2.3) and major-only (5) version strings —
-            // GitHub Actions Dependabot uses major-only tags like "from 5 to 6".
-            const regex = /from\s+([0-9]+)(?:\.[0-9]+)*[^\n]*to\s+([0-9]+)(?:\.[0-9]+)*/ig;
+            // Scoped to Dependabot's own update summary line ("Updates `pkg` from X to Y"
+            // or "Bumps `pkg` from X to Y"). Handles both semver (1.2.3) and major-only
+            // (5) tags used by GitHub Actions Dependabot. Avoids matching changelog text
+            // in the PR body which contains many unrelated version numbers.
+            const regex = /(?:Updates|Bumps)\s+`[^`]+`\s+from\s+([0-9]+)(?:\.[0-9]+)*\s+to\s+([0-9]+)(?:\.[0-9]+)*/ig;
             let m;
             let foundMatch = false;
             while ((m = regex.exec(body)) !== null) {

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,13 +26,15 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
             const body = pr.data.body || '';
-            const regex = /from\s+([0-9]+)\.([0-9]+)\.([0-9]+)[^\n]*to\s+([0-9]+)\.([0-9]+)\.([0-9]+)/ig;
+            // Matches both semver (1.2.3) and major-only (5) version strings —
+            // GitHub Actions Dependabot uses major-only tags like "from 5 to 6".
+            const regex = /from\s+([0-9]+)(?:\.[0-9]+)*[^\n]*to\s+([0-9]+)(?:\.[0-9]+)*/ig;
             let m;
             let foundMatch = false;
             while ((m = regex.exec(body)) !== null) {
               foundMatch = true;
               const fromMajor = parseInt(m[1], 10);
-              const toMajor = parseInt(m[4], 10);
+              const toMajor = parseInt(m[2], 10);
               if (toMajor > fromMajor) {
                 core.setFailed(`Contains a major version bump: ${m[0]}`);
               }


### PR DESCRIPTION
## Summary

- The auto-merge workflow used a regex requiring full semver (`X.Y.Z`) on both sides
- GitHub Actions Dependabot bumps use major-only tags: **"from 5 to 6"** — no minor/patch component
- This caused every GitHub Actions Dependabot PR to fail with `No version bump patterns found` instead of correctly detecting the major bump and blocking

**Fix:** make minor/patch groups optional (`(?:\.[0-9]+)*`) and fix the capture group index for `toMajor` (was `m[4]`, now `m[2]` since groups collapsed).

PR #343 (`actions/cache` 5→6) was the trigger — it should have failed with "Contains a major version bump" but failed with the wrong error instead.

## Test plan

- [ ] Merge this, then re-run the workflow on PR #343 — should fail with "Contains a major version bump: from 5 ... to 6"
- [ ] A future non-major GitHub Actions bump (e.g. `5.0.1` → `5.0.2` or `5` → `5`) should pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of major version bumps in automated dependency updates, including version tags that use major-only formats.
  * Dependabot updates with major-only version changes are now recognized correctly, reducing missed upgrade checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->